### PR TITLE
#3 [FEATURE] 프로메테우스용 엔드포인트를 위한 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 
     // Prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,6 +103,10 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 ---
 
 # 개발 환경 설정


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
스프링에서 프로메테우스 전용으로 엔드포인트를 열어주기 위해 의존성을 추가한다.

## 2. ✨새롭게 변경된 점
- `org.springframework.boot:spring-boot-starter-actuator` 의존성 추가
- `application.yml` 에 엔드포인트 허용

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
