### PR TITLE
feat : 게시글 신고, 사용자 차단/해제 기능

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,3 +67,4 @@ jobs:
           version_label: github-action-${{steps.current-time.outputs.formattedTime}}
           region: ap-northeast-2
           deployment_package: deployment-package.zip  # ZIP 파일로 변경
+          existing_bucket_name: elasticbeanstalk-ap-northeast-2-932353583320

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ feature/jiseob/#1 ]
+    branches: [ develop ]
 
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ feature/jiseob/#1 ]
 
 jobs:
   build:

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Duser.timezone=Asia/Seoul -jar *.jar
+web: java -Xms256m -Xmx256m -jar *.jar

--- a/src/main/java/com/example/trace/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/auth/config/SecurityConfig.java
@@ -54,7 +54,9 @@ public class SecurityConfig {
                         "/health",
                         "/"
                 ).permitAll()
-                .anyRequest().authenticated()
+                    .requestMatchers("/admin/**").hasRole("ADMIN")
+                    // 나머지 경로는 인증만 되면 접근 가능
+                    .anyRequest().authenticated()
             )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
         ;

--- a/src/main/java/com/example/trace/auth/dto/PrincipalDetails.java
+++ b/src/main/java/com/example/trace/auth/dto/PrincipalDetails.java
@@ -8,7 +8,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.stream.Collectors;
+import java.util.Collections;
 @Getter
 public class PrincipalDetails implements UserDetails {
 
@@ -23,10 +23,10 @@ public class PrincipalDetails implements UserDetails {
     // 해당 User의 권한을 리턴 하는 곳
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return user.getRoleList().stream()
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
+        // User 객체에서 role 정보를 가져와 GrantedAuthority 컬렉션으로 변환
+        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getKey()));
     }
+
 
     @Override
     public String getPassword() {

--- a/src/main/java/com/example/trace/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/trace/auth/service/KakaoOAuthService.java
@@ -12,6 +12,7 @@ import com.example.trace.mission.mission.DailyMission;
 import com.example.trace.mission.mission.Mission;
 import com.example.trace.mission.repository.DailyMissionRepository;
 import com.example.trace.mission.repository.MissionRepository;
+import com.example.trace.user.Role;
 import com.example.trace.user.User;
 import com.example.trace.auth.dto.*;
 
@@ -130,7 +131,7 @@ public class KakaoOAuthService {
                     .email(request.getEmail() != null ? request.getEmail() : null)
                     .nickname(request.getNickname() != null ? request.getNickname() : null)
                     .profileImageUrl(request.getProfileImageUrl() != null ? request.getProfileImageUrl() : null) // 기본 사진은 나중에 구현
-                    .role("ROLE_USER")
+                    .role(Role.USER)
                     .build();
 
             userRepository.save(newUser);

--- a/src/main/java/com/example/trace/global/errorcode/ReportErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/ReportErrorCode.java
@@ -7,13 +7,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ReportErrorCode implements ErrorCode {
-    INVALID_TARGET(HttpStatus.BAD_REQUEST, "Invalid report target. Provide postId or commentId."),
-    CANNOT_REPORT_YOUR_OWN_CONTENT(HttpStatus.FORBIDDEN, "You cannot report your own content."),
-    ALREADY_REPORTED(HttpStatus.CONFLICT, "You have already reported this content."),
-    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "Report not found."),
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "Post not found."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Comment not found."),
-    ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "This report has already been processed.");
+    INVALID_TARGET(HttpStatus.BAD_REQUEST, "잘못된 신고 대상입니다. postId 또는 commentId를 제공해주세요."),
+    CANNOT_REPORT_YOUR_OWN_CONTENT(HttpStatus.FORBIDDEN, "자신의 콘텐츠는 신고할 수 없습니다."),
+    ALREADY_REPORTED(HttpStatus.CONFLICT, "이미 신고한 콘텐츠입니다."),
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고를 찾을 수 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 신고입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/trace/global/errorcode/ReportErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/ReportErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.trace.global.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportErrorCode implements ErrorCode {
+    INVALID_TARGET(HttpStatus.BAD_REQUEST, "Invalid report target. Provide postId or commentId."),
+    CANNOT_REPORT_YOUR_OWN_CONTENT(HttpStatus.FORBIDDEN, "You cannot report your own content."),
+    ALREADY_REPORTED(HttpStatus.CONFLICT, "You have already reported this content."),
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "Report not found."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "Post not found."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Comment not found."),
+    ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "This report has already been processed.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/trace/global/exception/ReportException.java
+++ b/src/main/java/com/example/trace/global/exception/ReportException.java
@@ -1,0 +1,15 @@
+package com.example.trace.global.exception;
+
+import com.example.trace.global.errorcode.ReportErrorCode;
+import lombok.Getter;
+
+
+@Getter
+public class ReportException extends RuntimeException {
+    private final ReportErrorCode reportErrorCode;
+    public ReportException(ReportErrorCode reportErrorCode) {
+        super(reportErrorCode.getMessage());
+        this.reportErrorCode = reportErrorCode;
+    }
+}
+

--- a/src/main/java/com/example/trace/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/trace/global/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.trace.global.exception.*;
 import com.example.trace.global.response.ErrorResponse;
 import com.example.trace.global.response.GptErrorResponse;
 import com.example.trace.global.response.TokenErrorResponse;
+import com.example.trace.report.domain.Report;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -47,6 +48,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         PostErrorCode postErrorCode = e.getPostErrorCode();
         return handleExceptionInternal(postErrorCode);
     }
+    @ExceptionHandler(ReportException.class)
+    public ResponseEntity<Object> handleAuthException(ReportException e) {
+        ReportErrorCode reportErrorCode = e.getReportErrorCode();
+        return handleExceptionInternal(reportErrorCode);
+    }
+
+
 
     @ExceptionHandler(GptException.class)
     public ResponseEntity<Object> handleGptException(GptException e) {
@@ -88,6 +96,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private ResponseEntity<Object> handleExceptionInternal(GptErrorCode gptErrorCode, String failureReason) {
         return ResponseEntity.status(gptErrorCode.getHttpStatus())
                 .body(makeGptErrorResponse(gptErrorCode,failureReason));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ReportErrorCode reportErrorCode) {
+        return ResponseEntity.status(reportErrorCode.getHttpStatus())
+                .body(makeErrorResponse(reportErrorCode));
     }
 
     private TokenErrorResponse makeTokenErrorResponse(TokenErrorCode tokenErrorCode) {

--- a/src/main/java/com/example/trace/report/ReportReason.java
+++ b/src/main/java/com/example/trace/report/ReportReason.java
@@ -1,0 +1,19 @@
+package com.example.trace.report;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportReason {
+
+    INSULT("욕설/비방/인신공격"),
+    ILLEGAL("불법/범죄/불건전한 내용"),
+    LEWD("음란/선정/불쾌한 내용"),
+    SCAM("사기/허위정보/유출"),
+    COMMERCIAL("상업적 광고 및 판매"),
+    IRRELEVANT("게시판 성격에 부적절함"),
+    UNPLEASANT("불쾌감을 주는 사용자");
+
+    private final String description;
+}

--- a/src/main/java/com/example/trace/report/ReportReason.java
+++ b/src/main/java/com/example/trace/report/ReportReason.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReportReason {
 
+    // 신고 사유
     INSULT("욕설/비방/인신공격"),
     ILLEGAL("불법/범죄/불건전한 내용"),
     LEWD("음란/선정/불쾌한 내용"),

--- a/src/main/java/com/example/trace/report/ReportStatus.java
+++ b/src/main/java/com/example/trace/report/ReportStatus.java
@@ -1,0 +1,15 @@
+package com.example.trace.report;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportStatus {
+
+    PENDING("처리 대기"),
+    APPROVED("승인"),
+    REJECTED("기각");
+
+    private final String description;
+}

--- a/src/main/java/com/example/trace/report/controller/AdminReportController.java
+++ b/src/main/java/com/example/trace/report/controller/AdminReportController.java
@@ -1,0 +1,40 @@
+package com.example.trace.report.controller;
+
+import com.example.trace.global.response.ApiResponse;
+import com.example.trace.report.dto.AdminReportResponse;
+import com.example.trace.report.service.AdminReportService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/reports")
+@PreAuthorize("hasRole('ADMIN')") // ADMIN 권한이 있는 사용자만 접근 가능
+@Tag(name = "Admin Report Management", description = "관리자 신고 관리 API")
+public class AdminReportController {
+
+    private final AdminReportService adminReportService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminReportResponse>>> getReports() {
+        List<AdminReportResponse> reports = adminReportService.getReports();
+        return ResponseEntity.ok(ApiResponse.success("신고 목록 조회가 완료되었습니다.", reports));
+    }
+
+    @PostMapping("/{reportId}/approve")
+    public ResponseEntity<ApiResponse> approveReport(@PathVariable Long reportId) {
+        adminReportService.approveReport(reportId);
+        return ResponseEntity.ok(ApiResponse.success("신고를 승인하고 해당 콘텐츠를 삭제했습니다."));
+    }
+
+    @PostMapping("/{reportId}/reject")
+    public ResponseEntity<ApiResponse> rejectReport(@PathVariable Long reportId) {
+        adminReportService.rejectReport(reportId);
+        return ResponseEntity.ok(ApiResponse.success("신고를 기각 처리했습니다."));
+    }
+}

--- a/src/main/java/com/example/trace/report/controller/ReportController.java
+++ b/src/main/java/com/example/trace/report/controller/ReportController.java
@@ -1,0 +1,12 @@
+package com.example.trace.report.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+}

--- a/src/main/java/com/example/trace/report/controller/ReportController.java
+++ b/src/main/java/com/example/trace/report/controller/ReportController.java
@@ -26,24 +26,24 @@ public class ReportController {
     public ResponseEntity<ApiResponse> createReport(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody ReportRequest request) {
-        reportService.createReport(principalDetails.getUser().getId(), request);
+        reportService.createReport(principalDetails.getUser().getProviderId(), request);
         return ResponseEntity.ok(ApiResponse.success("신고가 성공적으로 접수되었습니다."));
     }
 
 
     @PostMapping("/block/{blockedId}")
     @Operation(summary = "사용자 차단", description = "사용자를 차단합니다.")
-    public ResponseEntity<Void> blockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long blockedId) {
-        Long blockerId = principalDetails.getUser().getId();
-        userBlockService.blockUser(blockerId, blockedId);
+    public ResponseEntity<Void> blockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable String blockedProviderId) {
+        String blockerProviderId = principalDetails.getUser().getProviderId();
+        userBlockService.blockUser(blockerProviderId, blockedProviderId);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/unblock/{blockedId}")
     @Operation(summary = "사용자 차단 해제", description = "차단된 사용자의 차단을 해제합니다.")
-    public ResponseEntity<Void> unblockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long blockedId) {
-        Long blockerId = principalDetails.getUser().getId();
-        userBlockService.unblockUser(blockerId, blockedId);
+    public ResponseEntity<Void> unblockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable String blockedProviderId) {
+        String blockerProviderId = principalDetails.getUser().getProviderId();
+        userBlockService.unblockUser(blockerProviderId, blockedProviderId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/trace/report/controller/ReportController.java
+++ b/src/main/java/com/example/trace/report/controller/ReportController.java
@@ -36,7 +36,7 @@ public class ReportController {
     public ResponseEntity<Void> blockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long blockedId) {
         Long blockerId = principalDetails.getUser().getId();
         userBlockService.blockUser(blockerId, blockedId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/unblock/{blockedId}")
@@ -44,6 +44,6 @@ public class ReportController {
     public ResponseEntity<Void> unblockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long blockedId) {
         Long blockerId = principalDetails.getUser().getId();
         userBlockService.unblockUser(blockerId, blockedId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/trace/report/controller/ReportController.java
+++ b/src/main/java/com/example/trace/report/controller/ReportController.java
@@ -4,6 +4,8 @@ import com.example.trace.auth.dto.PrincipalDetails;
 import com.example.trace.global.response.ApiResponse;
 import com.example.trace.report.dto.ReportRequest;
 import com.example.trace.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,10 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/reports")
 @RequiredArgsConstructor
+@Tag(name = "신고 API", description = "신고 관련 API")
 public class ReportController {
     private final ReportService reportService;
 
-    @PostMapping
+    @PostMapping(consumes = "application/json")
+    @Operation(summary = "신고 생성", description = "사용자가 신고를 생성합니다.")
     public ResponseEntity<ApiResponse> createReport(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody ReportRequest request) {

--- a/src/main/java/com/example/trace/report/controller/ReportController.java
+++ b/src/main/java/com/example/trace/report/controller/ReportController.java
@@ -4,22 +4,22 @@ import com.example.trace.auth.dto.PrincipalDetails;
 import com.example.trace.global.response.ApiResponse;
 import com.example.trace.report.dto.ReportRequest;
 import com.example.trace.report.service.ReportService;
+import com.example.trace.report.service.UserBlockService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/reports")
 @RequiredArgsConstructor
 @Tag(name = "신고 API", description = "신고 관련 API")
 public class ReportController {
+
     private final ReportService reportService;
+    private final UserBlockService userBlockService;
 
     @PostMapping(consumes = "application/json")
     @Operation(summary = "신고 생성", description = "사용자가 신고를 생성합니다.")
@@ -28,5 +28,22 @@ public class ReportController {
             @RequestBody ReportRequest request) {
         reportService.createReport(principalDetails.getUser().getId(), request);
         return ResponseEntity.ok(ApiResponse.success("신고가 성공적으로 접수되었습니다."));
+    }
+
+
+    @PostMapping("/block/{blockedId}")
+    @Operation(summary = "사용자 차단", description = "사용자를 차단합니다.")
+    public ResponseEntity<Void> blockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long blockedId) {
+        Long blockerId = principalDetails.getUser().getId();
+        userBlockService.blockUser(blockerId, blockedId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/unblock/{blockedId}")
+    @Operation(summary = "사용자 차단 해제", description = "차단된 사용자의 차단을 해제합니다.")
+    public ResponseEntity<Void> unblockUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long blockedId) {
+        Long blockerId = principalDetails.getUser().getId();
+        userBlockService.unblockUser(blockerId, blockedId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/trace/report/controller/ReportController.java
+++ b/src/main/java/com/example/trace/report/controller/ReportController.java
@@ -1,6 +1,14 @@
 package com.example.trace.report.controller;
 
+import com.example.trace.auth.dto.PrincipalDetails;
+import com.example.trace.global.response.ApiResponse;
+import com.example.trace.report.dto.ReportRequest;
+import com.example.trace.report.service.ReportService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,5 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/reports")
 @RequiredArgsConstructor
 public class ReportController {
+    private final ReportService reportService;
 
+    @PostMapping
+    public ResponseEntity<ApiResponse> createReport(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody ReportRequest request) {
+        reportService.createReport(principalDetails.getUser().getId(), request);
+        return ResponseEntity.ok(ApiResponse.success("신고가 성공적으로 접수되었습니다."));
+    }
 }

--- a/src/main/java/com/example/trace/report/domain/Report.java
+++ b/src/main/java/com/example/trace/report/domain/Report.java
@@ -1,0 +1,68 @@
+package com.example.trace.report.domain;
+
+import com.example.trace.post.domain.Comment;
+import com.example.trace.post.domain.Post;
+import com.example.trace.report.ReportReason;
+import com.example.trace.report.ReportStatus;
+import com.example.trace.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 신고자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    // 신고된 게시글 (댓글 신고의 경우 null)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    // 신고된 댓글 (게시글 신고의 경우 null)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportStatus reportStatus;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Report(User reporter, Post post, Comment comment, ReportReason reason) {
+        this.reporter = reporter;
+        this.post = post;
+        this.comment = comment;
+        this.reason = reason;
+        this.reportStatus = ReportStatus.PENDING;
+    }
+
+    public void approve() {
+        this.reportStatus = ReportStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.reportStatus = ReportStatus.REJECTED;
+    }
+
+}

--- a/src/main/java/com/example/trace/report/domain/UserBlock.java
+++ b/src/main/java/com/example/trace/report/domain/UserBlock.java
@@ -1,0 +1,41 @@
+package com.example.trace.report.domain;
+
+import com.example.trace.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_id", nullable = false)
+    private User blocker; // 차단한 사람
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_id", nullable = false)
+    private User blocked; // 차단된 사람
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserBlock(User blocker, User blocked) {
+        this.blocker = blocker;
+        this.blocked = blocked;
+    }
+}

--- a/src/main/java/com/example/trace/report/dto/AdminReportResponse.java
+++ b/src/main/java/com/example/trace/report/dto/AdminReportResponse.java
@@ -1,0 +1,38 @@
+package com.example.trace.report.dto;
+
+import com.example.trace.report.ReportReason;
+import com.example.trace.report.ReportStatus;
+import com.example.trace.report.domain.Report;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminReportResponse {
+    private final Long reportId;
+    private final String reporterName;
+    private final Long reporterId;
+    private final Long contentId;
+    private final String contentType;
+    private final ReportReason reason;
+    private final ReportStatus status;
+    private final LocalDateTime createdAt;
+
+    public static AdminReportResponse from(Report report) {
+        Long contentId = report.getPost() != null ? report.getPost().getId() : report.getComment().getId();
+        String contentType = report.getPost() != null ? "POST" : "COMMENT";
+
+        return AdminReportResponse.builder()
+                .reportId(report.getId())
+                .reporterName(report.getReporter().getNickname())
+                .reportId(report.getReporter().getId())
+                .contentId(contentId)
+                .contentType(contentType)
+                .reason(report.getReason())
+                .status(report.getReportStatus())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trace/report/dto/AdminReportResponse.java
+++ b/src/main/java/com/example/trace/report/dto/AdminReportResponse.java
@@ -27,7 +27,7 @@ public class AdminReportResponse {
         return AdminReportResponse.builder()
                 .reportId(report.getId())
                 .reporterName(report.getReporter().getNickname())
-                .reportId(report.getReporter().getId())
+                .reporterId(report.getReporter().getId())
                 .contentId(contentId)
                 .contentType(contentType)
                 .reason(report.getReason())

--- a/src/main/java/com/example/trace/report/dto/ReportRequest.java
+++ b/src/main/java/com/example/trace/report/dto/ReportRequest.java
@@ -1,0 +1,13 @@
+package com.example.trace.report.dto;
+
+import com.example.trace.report.ReportReason;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReportRequest {
+    private Long postId;
+    private Long commentId;
+    private ReportReason reason;
+}

--- a/src/main/java/com/example/trace/report/dto/ReportRequest.java
+++ b/src/main/java/com/example/trace/report/dto/ReportRequest.java
@@ -1,13 +1,18 @@
 package com.example.trace.report.dto;
 
 import com.example.trace.report.ReportReason;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "신고 요청 DTO")
 public class ReportRequest {
+    @Schema(description = "신고 대상 게시글 ID", example = "12345")
     private Long postId;
+    @Schema(description = "신고 대상 댓글 ID", example = "67890")
     private Long commentId;
+    @Schema(description = "신고 사유", example = "INSULT")
     private ReportReason reason;
 }

--- a/src/main/java/com/example/trace/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/trace/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.example.trace.report.repository;
+
+import com.example.trace.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/example/trace/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/trace/report/repository/ReportRepository.java
@@ -1,7 +1,14 @@
 package com.example.trace.report.repository;
 
+import com.example.trace.post.domain.Comment;
+import com.example.trace.post.domain.Post;
 import com.example.trace.report.domain.Report;
+import com.example.trace.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReportRepository extends JpaRepository<Report, Long> {
+    Optional<Report> findByReporterAndPost(User reporter, Post post);
+    Optional<Report> findByReporterAndComment(User reporter, Comment comment);
 }

--- a/src/main/java/com/example/trace/report/repository/UserBlockRepository.java
+++ b/src/main/java/com/example/trace/report/repository/UserBlockRepository.java
@@ -1,0 +1,11 @@
+package com.example.trace.report.repository;
+
+import com.example.trace.report.domain.UserBlock;
+import com.example.trace.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+    Optional<UserBlock> findByBlockerAndBlocked(User blocker, User blocked);
+}

--- a/src/main/java/com/example/trace/report/service/AdminReportService.java
+++ b/src/main/java/com/example/trace/report/service/AdminReportService.java
@@ -1,0 +1,63 @@
+package com.example.trace.report.service;
+
+import com.example.trace.global.errorcode.ReportErrorCode;
+import com.example.trace.global.exception.ReportException;
+import com.example.trace.post.repository.CommentRepository;
+import com.example.trace.post.repository.PostRepository;
+import com.example.trace.report.ReportStatus;
+import com.example.trace.report.domain.Report;
+import com.example.trace.report.dto.AdminReportResponse;
+import com.example.trace.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+
+    private final ReportRepository reportRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public List<AdminReportResponse> getReports() {
+        return reportRepository.findAll()
+                .stream()
+                .map(AdminReportResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void approveReport(Long reportId) {
+        Report report = findReportById(reportId);
+
+        if (report.getPost() != null) {
+            postRepository.delete(report.getPost());
+        } else if (report.getComment() != null) {
+            commentRepository.delete(report.getComment());
+        }
+
+        report.approve();
+    }
+
+    @Transactional
+    public void rejectReport(Long reportId) {
+        Report report = findReportById(reportId);
+        report.reject();
+    }
+
+    private Report findReportById(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
+
+        if (report.getReportStatus() != ReportStatus.PENDING) {
+            throw new ReportException(ReportErrorCode.ALREADY_PROCESSED);
+        }
+        return report;
+    }
+}

--- a/src/main/java/com/example/trace/report/service/ReportService.java
+++ b/src/main/java/com/example/trace/report/service/ReportService.java
@@ -26,8 +26,8 @@ public class ReportService {
     private final CommentRepository commentRepository;
 
     @Transactional
-    public void createReport(Long reporterId, ReportRequest request) {
-        User reporter = userRepository.findById(reporterId)
+    public void createReport(String providerId, ReportRequest request) {
+        User reporter = userRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         if (request.getPostId() != null && request.getCommentId() == null) {
@@ -43,7 +43,7 @@ public class ReportService {
         Post post = postRepository.findById(request.getPostId())
                 .orElseThrow(() -> new ReportException(ReportErrorCode.POST_NOT_FOUND));
 
-        if (post.getUser().getId().equals(reporter.getId())) {
+        if (post.getUser().getProviderId().equals(reporter.getProviderId())) {
             throw new ReportException(ReportErrorCode.CANNOT_REPORT_YOUR_OWN_CONTENT);
         }
 
@@ -63,7 +63,7 @@ public class ReportService {
         Comment comment = commentRepository.findById(request.getCommentId())
                 .orElseThrow(() -> new ReportException(ReportErrorCode.COMMENT_NOT_FOUND));
 
-        if (comment.getUser().getId().equals(reporter.getId())) {
+        if (comment.getUser().getProviderId().equals(reporter.getProviderId())) {
             throw new ReportException(ReportErrorCode.CANNOT_REPORT_YOUR_OWN_CONTENT);
         }
 

--- a/src/main/java/com/example/trace/report/service/ReportService.java
+++ b/src/main/java/com/example/trace/report/service/ReportService.java
@@ -1,0 +1,81 @@
+package com.example.trace.report.service;
+
+import com.example.trace.auth.repository.UserRepository;
+import com.example.trace.global.errorcode.ReportErrorCode;
+import com.example.trace.global.errorcode.UserErrorCode;
+import com.example.trace.global.exception.ReportException;
+import com.example.trace.global.exception.UserException;
+import com.example.trace.post.domain.Comment;
+import com.example.trace.post.domain.Post;
+import com.example.trace.post.repository.CommentRepository;
+import com.example.trace.post.repository.PostRepository;
+import com.example.trace.report.domain.Report;
+import com.example.trace.report.dto.ReportRequest;
+import com.example.trace.report.repository.ReportRepository;
+import com.example.trace.user.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ReportService {
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void createReport(Long reporterId, ReportRequest request) {
+        User reporter = userRepository.findById(reporterId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        if (request.getPostId() != null && request.getCommentId() == null) {
+            reportPost(reporter, request);
+        } else if (request.getPostId() == null && request.getCommentId() != null) {
+            reportComment(reporter, request);
+        } else {
+            throw new ReportException(ReportErrorCode.INVALID_TARGET);
+        }
+    }
+
+    private void reportPost(User reporter, ReportRequest request) {
+        Post post = postRepository.findById(request.getPostId())
+                .orElseThrow(() -> new ReportException(ReportErrorCode.POST_NOT_FOUND));
+
+        if (post.getUser().getId().equals(reporter.getId())) {
+            throw new ReportException(ReportErrorCode.CANNOT_REPORT_YOUR_OWN_CONTENT);
+        }
+
+        reportRepository.findByReporterAndPost(reporter, post).ifPresent(r -> {
+            throw new ReportException(ReportErrorCode.ALREADY_REPORTED);
+        });
+
+        Report report = Report.builder()
+                .reporter(reporter)
+                .post(post)
+                .reason(request.getReason())
+                .build();
+        reportRepository.save(report);
+    }
+
+    private void reportComment(User reporter, ReportRequest request) {
+        Comment comment = commentRepository.findById(request.getCommentId())
+                .orElseThrow(() -> new ReportException(ReportErrorCode.COMMENT_NOT_FOUND));
+
+        if (comment.getUser().getId().equals(reporter.getId())) {
+            throw new ReportException(ReportErrorCode.CANNOT_REPORT_YOUR_OWN_CONTENT);
+        }
+
+        reportRepository.findByReporterAndComment(reporter, comment).ifPresent(r -> {
+            throw new ReportException(ReportErrorCode.ALREADY_REPORTED);
+        });
+
+        Report report = Report.builder()
+                .reporter(reporter)
+                .comment(comment)
+                .reason(request.getReason())
+                .build();
+        reportRepository.save(report);
+    }
+}

--- a/src/main/java/com/example/trace/report/service/UserBlockService.java
+++ b/src/main/java/com/example/trace/report/service/UserBlockService.java
@@ -1,0 +1,50 @@
+package com.example.trace.report.service;
+
+import com.example.trace.auth.repository.UserRepository;
+import com.example.trace.report.domain.UserBlock;
+import com.example.trace.report.repository.UserBlockRepository;
+import com.example.trace.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserBlockService {
+
+    private final UserRepository userRepository;
+    private final UserBlockRepository userBlockRepository;
+
+    public void blockUser(Long blockerId, Long blockedId) {
+        if (blockerId.equals(blockedId)) {
+            throw new IllegalArgumentException("자기 자신을 차단할 수 없습니다");
+        }
+        User blocker = userRepository.findById(blockerId)
+                .orElseThrow(() -> new IllegalArgumentException("차단하는 사용자를 찾을 수 없습니다."));
+        User blocked = userRepository.findById(blockedId)
+                .orElseThrow(() -> new IllegalArgumentException("차단될 사용자들 찾을 수 없습니다."));
+
+        userBlockRepository.findByBlockerAndBlocked(blocker, blocked)
+                .ifPresent(existingBlock -> {
+                    throw new IllegalArgumentException("이미 차단한 사용자입니다.");
+                });
+
+        UserBlock userBlock = UserBlock.builder()
+                .blocker(blocker)
+                .blocked(blocked)
+                .build();
+
+        userBlockRepository.save(userBlock);
+    }
+
+    public void unblockUser(Long blockerId, Long blockedId) {
+        User blocker = userRepository.findById(blockerId)
+                .orElseThrow(() -> new IllegalArgumentException("차단 해제하는 사용자를 찾을 수 없습니다."));
+        User blocked = userRepository.findById(blockedId)
+                .orElseThrow(() -> new IllegalArgumentException("차단 해제될 사용자를 찾을 수 없습니다."));
+
+        UserBlock userBlock = userBlockRepository.findByBlockerAndBlocked(blocker, blocked)
+                .orElseThrow(() -> new IllegalArgumentException("차단된 사용자가 아닙니다."));
+
+        userBlockRepository.delete(userBlock);
+    }
+}

--- a/src/main/java/com/example/trace/report/service/UserBlockService.java
+++ b/src/main/java/com/example/trace/report/service/UserBlockService.java
@@ -14,13 +14,13 @@ public class UserBlockService {
     private final UserRepository userRepository;
     private final UserBlockRepository userBlockRepository;
 
-    public void blockUser(Long blockerId, Long blockedId) {
-        if (blockerId.equals(blockedId)) {
+    public void blockUser(String blockerProviderId, String blockedProviderId) {
+        if (blockerProviderId.equals(blockedProviderId)) {
             throw new IllegalArgumentException("자기 자신을 차단할 수 없습니다");
         }
-        User blocker = userRepository.findById(blockerId)
+        User blocker = userRepository.findByProviderId(blockerProviderId)
                 .orElseThrow(() -> new IllegalArgumentException("차단하는 사용자를 찾을 수 없습니다."));
-        User blocked = userRepository.findById(blockedId)
+        User blocked = userRepository.findByProviderId(blockedProviderId)
                 .orElseThrow(() -> new IllegalArgumentException("차단될 사용자들 찾을 수 없습니다."));
 
         userBlockRepository.findByBlockerAndBlocked(blocker, blocked)
@@ -36,10 +36,10 @@ public class UserBlockService {
         userBlockRepository.save(userBlock);
     }
 
-    public void unblockUser(Long blockerId, Long blockedId) {
-        User blocker = userRepository.findById(blockerId)
+    public void unblockUser(String blockerProviderId, String blockedProviderId) {
+        User blocker = userRepository.findByProviderId(blockerProviderId)
                 .orElseThrow(() -> new IllegalArgumentException("차단 해제하는 사용자를 찾을 수 없습니다."));
-        User blocked = userRepository.findById(blockedId)
+        User blocked = userRepository.findByProviderId(blockedProviderId)
                 .orElseThrow(() -> new IllegalArgumentException("차단 해제될 사용자를 찾을 수 없습니다."));
 
         UserBlock userBlock = userBlockRepository.findByBlockerAndBlocked(blocker, blocked)

--- a/src/main/java/com/example/trace/user/Role.java
+++ b/src/main/java/com/example/trace/user/Role.java
@@ -1,0 +1,13 @@
+package com.example.trace.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+}

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -2,11 +2,10 @@ package com.example.trace.user;
 
 import com.example.trace.gpt.dto.VerificationDto;
 import jakarta.persistence.*;
-import lombok.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "users")
@@ -40,14 +39,11 @@ public class User {
     //spring security용으로 일단 두기.
     private String password;
     private String username;
-    private String role;
 
-    public List<String> getRoleList() {
-        if(this.role != null && !this.role.isEmpty()) {
-            return Arrays.asList(this.role.split(","));
-        }
-        return new ArrayList<>();
-    }
+    @Enumerated(EnumType.STRING) // Enum 이름을 DB에 문자열로 저장
+    @Column(nullable = false)
+    private Role role;
+
 
     public void updateNickname(String newNickname) {
         this.nickname = newNickname;
@@ -57,9 +53,9 @@ public class User {
         this.profileImageUrl = newProfileImageUrl;
     }
 
-    public void updateVerification(VerificationDto verificationDto){
-        if(verificationDto.isTextResult() || verificationDto.isImageResult()) verificationCount++;
-        if(verificationDto.isImageResult()) this.verificationScore += 10;
-        if(verificationDto.isTextResult()) this.verificationScore += 5;
+    public void updateVerification(VerificationDto verificationDto) {
+        if (verificationDto.isTextResult() || verificationDto.isImageResult()) verificationCount++;
+        if (verificationDto.isImageResult()) this.verificationScore += 10;
+        if (verificationDto.isTextResult()) this.verificationScore += 5;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,5 @@
-# 애플리케이션 기본 설정
+# 애플리케이션 기본 설정 
+# CICD 테스트
 spring:
   application:
     name: Trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,8 @@ springdoc:
     - /comments/**
     - /missions/**
     - /fcm/**
+    - /reports/**
+    - /admin/reports/**
 
 # OAuth2 클라이언트 설정 - API 키 관리, 외부에 노출되면 안 됨
 oauth2:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

- procfile로 JVM 힙 메모리 절약
- 스왑 메모리 1GB 생성

## 2. ✨새롭게 변경된 점

- **게시글 신고 기능**

사용자가 게시글 혹은 댓글을 신고 시, Report 테이블 신고 정보를 저장.

관리자 api를 통해 approve 하여 해당 게시글을 삭제하거나, reject 하여 신고 처리 거절할 수 있다.

관리자 API에는 ROLE이 ADMIN으로 설정된 사용자만 요청을 보낼 수 있다.
(securityConfig 파일 참고)

- **사용자 차단/해제 기능**

사용자를 차단하면, 해당 사용자의 게시글과 댓글이 조회에서 뜨지 않는다. (차단한 사람 기준)

- **procfile을 통해 JVM 최소/최대 힙 메모리 명시**

JVM은 시작될 때 일정량의 힙 메모리를 할당받음.

할당받는 메모리 크기를 명시하지 않으면 인스턴스의 전체 메모리 중 일정 비율을 최대로 사용하려고 시도하기 때문에, 시스템의 메모리가 부족할 수 있다. 잠재적인 서버 과부하의 원인이 아닐까 생각됨.

따라서 Procfile을 통해 메모리 사이즈를 제한해야한다.

Procfile은 클라우드 환경 등에 배포할 때, 앱을 실행하는 명령어를 명시하는 것. 

```
web: java -Xms256m -Xmx256m -jar *.jar
```
-Xms256m : 최소 힙 메모리 사이즈를 256mb로 설정
-Xmx256m : 최대 힙 메모리 사이즈를 256mb로 설정

해당 Procfile을 루트 디렉터리에 끼워서 배포하였더니 다음과 같은 메모리 사용량을 보였다.

```
              total        used        free      shared  buff/cache   available
Mem:           949Mi       519Mi        71Mi        83Mi       358Mi       204Mi
Swap:          1.0Gi       131Mi       892Mi

```

(procfile 적용 전에 메모리 사용량도 캡처해놨는데 어디갔는지 모르겠다... ㅠㅠ)

하지만 확실한건 available이 두 자리수 였는데, **최소 두 배 이상 증가**했다는 것.

- 스왑 메모리 생성

스왑 메모리를 1GB 정도 생성하여 활성화 해놓았다.
하지만 메모리 사용량이 크게 개선된 것 같지는 않다.

## 3. 🔖 기타 사항

- 사용자를 차단했을 때, 해당 사용자의 댓글은 '차단한 사용자의 댓글입니다' 라고 뜰 수 있도록 기능 추가해야한다.

- 사용자 신고 기능과 차단 기능은 유사한 기능이라고 생각하여 같은 엔드포인트를 사용하였는데, 앱 팀원의 코드래빗에서 분리하는게 좋다고 지적했다. 고민해봐야할 것 같다.

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
