### PR TITLE
#3 [FIX] 기존에 사용중이던 management 설정과 병합

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,23 +93,6 @@ logging:
 
 firebase:
   config-path: firebase/firebase_service_key.json
-
-# 메트릭/Actuator 설정
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, prometheus
-  endpoint:
-    prometheus:
-      enabled: true
-  metrics:
-    tags:
-      application: ${spring.application.name}
-  prometheus:
-    metrics:
-      export:
-        enabled: true
 ---
 
 # 개발 환경 설정
@@ -175,14 +158,24 @@ server:
     max-swallow-size: 2MB
 
 # 메모리 사용량 최적화를 위한 JVM 설정
+# 메트릭/Actuator 설정
 management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health, info, prometheus
   endpoint:
+    prometheus:
+      enabled: true
     health:
       show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 ---
 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
기존에 사용중이던 management 세팅과 프로메테우스 연동을 위해 추가한 세팅과 병합한다.

## 2. ✨새롭게 변경된 점
- 프로메테우스 설정이 상위에 있고, dev에 `management` 설정이 한 번 더 되어있어서 덮어씌워짐
-> 결과적으로 로컬에선 되는데 원격 서버에서 안되는 상황 발생
-> 일단 배포환경에서만 작동하도록 수정

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)
<img width="1108" height="348" alt="스크린샷 2025-07-16 오후 5 31 02" src="https://github.com/user-attachments/assets/4acbc424-1067-4781-aa97-9f2bc6a0fe68" />


## 5. 💡알게된 혹은 궁금한 사항들
