### PR TITLE
처음 10개의 알림 목록을 가져오는 쿼리문 추가

### DIFF
--- a/src/main/java/com/example/trace/notification/repository/NotificationEventRepository.java
+++ b/src/main/java/com/example/trace/notification/repository/NotificationEventRepository.java
@@ -12,7 +12,8 @@ import org.springframework.data.repository.query.Param;
 public interface NotificationEventRepository extends JpaRepository<NotificationEvent, Long> {
     List<NotificationEvent> findAllByRefIdAndUser(Long refId, User user);
 
-    List<NotificationEvent> findFirstPage(User user, Pageable pageable);
+    @Query("SELECT n FROM NotificationEvent n WHERE n.user = :user ORDER BY n.createdAt DESC, n.id DESC")
+    List<NotificationEvent> findFirstPage(@Param("user") User user, Pageable pageable);
 
     @Query("""
                 SELECT n FROM NotificationEvent n


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
알림 목록을 조회하는 메서드에 

1. Spring Data JPA 가 인식할 수 있는 메서드 명을 사용하거나
2. `@Query`로 직접 쿼리를 작성

하지 않아서 발생하는 앱 실행 오류를 수정

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
