### PR TITLE
[REFACTOR] Swagger 게시글 수정 API에 Multipart 이미지를 첨부할 수 있도록 변경

### DIFF
--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -140,7 +140,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/{id}")
+    @PutMapping(path = "/{id}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
     public ResponseEntity<PostDto> updatePost(
             @PathVariable Long id,


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
Swagger 게시글 수정 api 호출 시 이미지 첨부가 되지 않음.
`consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}`를 `PutMapping`에 추가하여 스웨거에서도 멀티파트 이미지 전송이 가능하도록 변경함

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
