### PR TITLE
feat : 선행 인증 횟수 제한

### DIFF
--- a/src/main/java/com/example/trace/auth/Util/RedisUtil.java
+++ b/src/main/java/com/example/trace/auth/Util/RedisUtil.java
@@ -1,9 +1,15 @@
 package com.example.trace.auth.Util;
 
-import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
+
 @Component
+@Slf4j
 public class RedisUtil {
 
     private final RedisTemplate<String, Object> redisTemplate;
@@ -17,15 +23,32 @@ public class RedisUtil {
         redisTemplate.opsForValue().set(key, val, time, timeUnit);
     }
 
-    public boolean hasKey(String key) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
-    }
-
     public Object get(String key) {
         return redisTemplate.opsForValue().get(key);
     }
 
     public boolean delete(String key) {
         return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+    public Long decrement(String key) {
+        return redisTemplate.opsForValue().decrement(key);
+    }
+
+    public Long incrementWithTTL(String key, long timeout, TimeUnit timeUnit) {
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count == null) {
+            log.error("Redis increment operation returned null for key: {}", key);
+            throw new RuntimeException("Redis increment operation failed");
+        } else if (count == 1) {
+            // 첫 번째 증가일 때만 TTL 설정
+            redisTemplate.expire(key, timeout, timeUnit);
+        }
+        return count;
+    }
+
+    public String getDailyVerificationKey(String providerId) {
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        return String.format("verification:daily:%s:%s", providerId, today);
     }
 }

--- a/src/main/java/com/example/trace/global/errorcode/GptErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/GptErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GptErrorCode implements ErrorCode {
     GPT_LOGIC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GPT의 논리적인 오류입니다. 텍스트가 선행이 아니라면, 이미지는 인증될 수 없습니다."),
-    WRONG_CONTENT(HttpStatus.BAD_REQUEST,  "게시글 내용이 선행과 관련이 없습니다."),
+    WRONG_CONTENT(HttpStatus.BAD_REQUEST, "게시글 내용이 선행과 관련이 없습니다."),
+    DAILY_VERIFICATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "오늘 인증 횟수를 초과했습니다. 내일 다시 시도해주세요."),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
@@ -7,7 +7,9 @@ import com.example.trace.mission.mission.DailyMission;
 import com.example.trace.post.dto.post.PostCreateDto;
 
 public interface PostVerificationService {
-    VerificationDto verifyPost(PostCreateDto postCreateDto,String providerId);
+    VerificationDto verifyPost(PostCreateDto postCreateDto, String providerId);
+
     Verification makeVerification(VerificationDto verificationDto);
-    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto,DailyMission assignedDailyMission);
+
+    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, DailyMission assignedDailyMission, String providerId);
 } 

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.trace.gpt.service;
 
+import com.example.trace.auth.Util.RedisUtil;
+import com.example.trace.auth.repository.UserRepository;
 import com.example.trace.global.errorcode.GptErrorCode;
 import com.example.trace.global.errorcode.PostErrorCode;
 import com.example.trace.global.exception.GptException;
@@ -8,35 +10,29 @@ import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.mission.mission.DailyMission;
-import com.example.trace.mission.repository.DailyMissionRepository;
 import com.example.trace.post.dto.post.PostCreateDto;
 import com.example.trace.user.User;
-import com.example.trace.auth.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.completion.chat.ChatMessageRole;
 import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.Base64;
-import java.io.IOException;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -45,16 +41,29 @@ public class PostVerificationServiceImpl implements PostVerificationService {
 
     private final OpenAiService openAiService;
     private final UserRepository userRepository;
-    private final DailyMissionRepository dailyMissionRepository;
+    private final RedisUtil redisUtil;
     private static final String MODEL = "gpt-4o";
-    
+    private static final int DAILY_VERIFICATION_LIMIT = 10;
+
     @Value("${openai.api.key}")
     private String openaiApiKey;
-    
+
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto,DailyMission assignedDailyMission){
+    private void checkAndIncrementDailyVerificationCount(String userId) {
+        String key = redisUtil.getDailyVerificationKey(userId);
+        Long currentCount = redisUtil.incrementWithTTL(key, 24, TimeUnit.HOURS);
+
+        log.info("사용자 {} 일일 인증 횟수: {}/{}", userId, currentCount, DAILY_VERIFICATION_LIMIT);
+
+        if (currentCount > DAILY_VERIFICATION_LIMIT) {
+            redisUtil.decrement(key); // 초과된 인증 횟수는 감소시킴
+            throw new GptException(GptErrorCode.DAILY_VERIFICATION_LIMIT_EXCEEDED, "인증 횟수 초과");
+        }
+    }
+
+    public VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, DailyMission assignedDailyMission, String providerId) {
 
         if (submitDto.getContent() == null || submitDto.getContent().isEmpty()) {
             throw new PostException(PostErrorCode.CONTENT_EMPTY);
@@ -62,6 +71,9 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         if (submitDto.getTitle() == null || submitDto.getTitle().isEmpty()) {
             throw new PostException(PostErrorCode.TITLE_EMPTY);
         }
+
+        checkAndIncrementDailyVerificationCount(providerId);
+
 
         String requestContent = submitDto.getContent();
         List<MultipartFile> images = submitDto.getImageFiles();
@@ -72,7 +84,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             VerificationDto result = verifyMissionTextOnly(requestContent, assignedContent);
             if (!result.isTextResult()) {
                 String failureReason = result.getFailureReason();
-                log.info("실패 이유 : {}",failureReason);
+                log.info("실패 이유 : {}", failureReason);
                 throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
             }
             return result;
@@ -80,7 +92,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             VerificationDto result = verifyMissionTextAndImages(requestContent, assignedContent, images);
             if (!result.isTextResult() || !result.isImageResult()) {
                 String failureReason = result.getFailureReason();
-                log.info("실패 이유 : {}",failureReason);
+                log.info("실패 이유 : {}", failureReason);
                 throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
             }
             return result;
@@ -91,9 +103,11 @@ public class PostVerificationServiceImpl implements PostVerificationService {
 
 
     @Override
-    public VerificationDto verifyPost(PostCreateDto postCreateDto,String providerId) {
+    public VerificationDto verifyPost(PostCreateDto postCreateDto, String providerId) {
         User user = userRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
+
+        checkAndIncrementDailyVerificationCount(providerId);
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {
             throw new PostException(PostErrorCode.CONTENT_EMPTY);
@@ -108,9 +122,9 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         if (images == null || images.isEmpty()) {
             // Only text verification is needed
             VerificationDto result = verifyTextOnly(content);
-            if(!result.isTextResult()){
+            if (!result.isTextResult()) {
                 String failureReason = result.getFailureReason();
-                throw new GptException(GptErrorCode.WRONG_CONTENT,failureReason);
+                throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
             }
             return result;
         } else {
@@ -118,14 +132,14 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             VerificationDto result = verifyTextAndImages(content, images);
             if (!result.isTextResult() || !result.isImageResult()) {
                 String failureReason = result.getFailureReason();
-                throw new GptException(GptErrorCode.WRONG_CONTENT,failureReason);
+                throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
             }
             return result;
         }
     }
 
-    public Verification makeVerification(VerificationDto verificationDto){
-        if(verificationDto.isTextResult() && verificationDto.isImageResult()){
+    public Verification makeVerification(VerificationDto verificationDto) {
+        if (verificationDto.isTextResult() && verificationDto.isImageResult()) {
             Verification verification = Verification.builder()
                     .isTextVerified(true)
                     .isImageVerified(true)
@@ -133,8 +147,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                     .successReason(verificationDto.getSuccessReason())
                     .build();
             return verification;
-        }
-        else if (verificationDto.isTextResult() && !verificationDto.isImageResult()) {
+        } else if (verificationDto.isTextResult() && !verificationDto.isImageResult()) {
             Verification verification = Verification.builder()
                     .isTextVerified(true)
                     .isImageVerified(false)
@@ -142,8 +155,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                     .successReason(verificationDto.getSuccessReason())
                     .build();
             return verification;
-        }
-        else if(!verificationDto.isTextResult() && !verificationDto.isImageResult()){
+        } else if (!verificationDto.isTextResult() && !verificationDto.isImageResult()) {
             Verification verification = Verification.builder()
                     .isTextVerified(false)
                     .isImageVerified(false)
@@ -151,16 +163,15 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                     .successReason(verificationDto.getSuccessReason())
                     .build();
             return verification;
-        }
-        else {
-            throw new GptException(GptErrorCode.GPT_LOGIC_ERROR,null);
+        } else {
+            throw new GptException(GptErrorCode.GPT_LOGIC_ERROR, null);
         }
     }
 
-    
+
     private VerificationDto verifyTextOnly(String content) {
         List<ChatMessage> messages = new ArrayList<>();
-        
+
         String systemPrompt = "You are an AI assistant tasked with verifying if the given text describes an act of kindness. " +
                 "Respond in the following format exactly:\n" +
                 "text_result: true/false\n" +
@@ -176,7 +187,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                 .model(MODEL)
                 .messages(messages)
                 .build();
-        
+
         try {
             String response = openAiService.createChatCompletion(request).getChoices().get(0).getMessage().getContent();
             return parseVerificationResponse(response);
@@ -185,11 +196,11 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             return VerificationDto.textOnlyFailure("Failed to verify text: " + e.getMessage());
         }
     }
-    
+
     private VerificationDto verifyTextAndImages(String content, List<MultipartFile> images) {
         try {
             List<ChatMessage> messages = new ArrayList<>();
-            
+
             String systemPrompt = "You are an AI assistant tasked with verifying if the given text describes an act of kindness " +
                     "and if the provided images properly describe the text and relate to acts of kindness. " +
                     "Respond in the following format exactly:\n" +
@@ -205,46 +216,46 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                     "1. Does the text describe an act of kindness?\n" +
                     "2. Do the images properly describe the text and relate to acts of kindness?\n\n" +
                     "Text: " + content;
-            
+
             ChatMessage userMessage = new ChatMessage(ChatMessageRole.USER.value(), userPrompt);
             messages.add(userMessage);
 
             // We'll need to build a multimodal request
             // Since older versions of the client don't support multimodal content directly,
             // we'll need to use a direct REST call for the images part
-            
+
             if (images != null && !images.isEmpty()) {
                 // For multimodal requests with images, we need to use direct REST API call
                 HttpHeaders headers = new HttpHeaders();
                 headers.setContentType(MediaType.APPLICATION_JSON);
                 headers.set("Authorization", "Bearer " + openaiApiKey);
-                
+
                 // API request body
                 Map<String, Object> requestBody = new HashMap<>();
                 requestBody.put("model", MODEL);
                 requestBody.put("max_tokens", 500);
-                
+
                 // Messages array
                 List<Map<String, Object>> apiMessages = new ArrayList<>();
-                
+
                 // System message
                 Map<String, Object> systemMessage = new HashMap<>();
                 systemMessage.put("role", "system");
                 systemMessage.put("content", systemPrompt);
                 apiMessages.add(systemMessage);
-                
+
                 // User message with text and images
                 Map<String, Object> apiUserMessage = new HashMap<>();
                 apiUserMessage.put("role", "user");
-                
+
                 List<Map<String, Object>> contentItems = new ArrayList<>();
-                
+
                 // Text content
                 Map<String, Object> textContent = new HashMap<>();
                 textContent.put("type", "text");
                 textContent.put("text", userPrompt);
                 contentItems.add(textContent);
-                
+
                 // Image content
                 for (MultipartFile image : images) {
                     try {
@@ -252,11 +263,11 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                         if (base64Image != null) {
                             Map<String, Object> imageContent = new HashMap<>();
                             imageContent.put("type", "image_url");
-                            
+
                             Map<String, String> imageUrl = new HashMap<>();
                             imageUrl.put("url", "data:image/jpeg;base64," + base64Image);
                             log.info("Image base64 length: {}", base64Image.length());
-                            
+
                             imageContent.put("image_url", imageUrl);
                             contentItems.add(imageContent);
                         } else {
@@ -266,43 +277,43 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                         log.error("Error processing image", e);
                     }
                 }
-                
+
                 apiUserMessage.put("content", contentItems);
                 apiMessages.add(apiUserMessage);
-                
+
                 requestBody.put("messages", apiMessages);
-                
+
                 // Send API request
                 HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
-                
+
                 // Log request (without full base64 data)
                 try {
                     String debugRequestBody = objectMapper.writeValueAsString(requestBody);
-                    
+
                     if (debugRequestBody.contains("\"url\":\"data:image/jpeg;base64,")) {
                         debugRequestBody = debugRequestBody.replaceAll(
-                            "(\"url\":\"data:image/jpeg;base64,)[^\"]+", 
-                            "$1...[BASE64_DATA_LENGTH: " + 
-                            debugRequestBody.split("\"url\":\"data:image/jpeg;base64,")[1].split("\"")[0].length() + 
-                            "]..."
+                                "(\"url\":\"data:image/jpeg;base64,)[^\"]+",
+                                "$1...[BASE64_DATA_LENGTH: " +
+                                        debugRequestBody.split("\"url\":\"data:image/jpeg;base64,")[1].split("\"")[0].length() +
+                                        "]..."
                         );
                     }
-                    
+
                     log.info("OpenAI API Request: {}", debugRequestBody);
                 } catch (Exception e) {
                     log.warn("Failed to log request body", e);
                 }
-                
+
                 ResponseEntity<String> responseEntity = restTemplate.postForEntity(
-                        "https://api.openai.com/v1/chat/completions", 
-                        request, 
+                        "https://api.openai.com/v1/chat/completions",
+                        request,
                         String.class);
-                
+
                 log.info("OpenAI API Response Status: {}", responseEntity.getStatusCode());
-                
+
                 // Parse response
                 Map<String, Object> responseMap = objectMapper.readValue(responseEntity.getBody(), Map.class);
-                
+
                 // Check for errors
                 if (responseMap.containsKey("error")) {
                     Map<String, Object> error = (Map<String, Object>) responseMap.get("error");
@@ -310,12 +321,12 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                     log.error("OpenAI API Error: {}", errorMessage);
                     return VerificationDto.bothFailure("OpenAI API Error: " + errorMessage);
                 }
-                
+
                 List<Map<String, Object>> choices = (List<Map<String, Object>>) responseMap.get("choices");
                 Map<String, Object> firstChoice = choices.get(0);
                 Map<String, Object> message = (Map<String, Object>) firstChoice.get("message");
                 String responseContent = (String) message.get("content");
-                
+
                 return parseVerificationResponse(responseContent);
             } else {
                 // For text-only requests, we can use the OpenAI client
@@ -324,10 +335,10 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                         .messages(messages)
                         .maxTokens(500)
                         .build();
-                
+
                 String response = openAiService.createChatCompletion(request)
                         .getChoices().get(0).getMessage().getContent();
-                
+
                 return parseVerificationResponse(response);
             }
         } catch (Exception e) {
@@ -518,7 +529,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             return VerificationDto.bothFailure("Failed to verify content: " + e.getMessage());
         }
     }
-    
+
     /**
      * Encodes a MultipartFile to base64 string
      */
@@ -527,22 +538,22 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             log.error("Empty or null file");
             return null;
         }
-        
+
         try {
             byte[] fileBytes = file.getBytes();
             if (fileBytes.length == 0) {
                 log.error("File contains no data");
                 return null;
             }
-            
+
             // Check file size (20MB limit)
             if (fileBytes.length > 20 * 1024 * 1024) {
                 log.error("File too large: {} bytes", fileBytes.length);
                 return null;
             }
-            
+
             String base64 = Base64.getEncoder().encodeToString(fileBytes);
-            log.info("Successfully encoded image, size: {} bytes, base64 length: {}", 
+            log.info("Successfully encoded image, size: {} bytes, base64 length: {}",
                     fileBytes.length, base64.length());
             return base64;
         } catch (IOException e) {
@@ -550,13 +561,13 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             return null;
         }
     }
-    
+
     private VerificationDto parseVerificationResponse(String response) {
         boolean textResult = false;
         boolean imageResult = false;
         String successReason = null;
         String failureReason = null;
-        
+
         // Extract text_result
         Pattern textPattern = Pattern.compile("text_result\\s*:\\s*(true|false)", Pattern.CASE_INSENSITIVE);
         Matcher textMatcher = textPattern.matcher(response);
@@ -564,7 +575,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             textResult = "true".equalsIgnoreCase(textMatcher.group(1));
             log.info("Text result: {}", textResult);
         }
-        
+
         // Extract image_result
         Pattern imagePattern = Pattern.compile("image_result\\s*:\\s*(true|false)", Pattern.CASE_INSENSITIVE);
         Matcher imageMatcher = imagePattern.matcher(response);
@@ -572,7 +583,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             imageResult = "true".equalsIgnoreCase(imageMatcher.group(1));
             log.info("Image result: {}", imageResult);
         }
-        
+
         // Extract success_reason
         Pattern successPattern = Pattern.compile("success_reason\\s*:\\s*(.+?)(?=\\n|$)", Pattern.CASE_INSENSITIVE);
         Matcher successMatcher = successPattern.matcher(response);
@@ -580,7 +591,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             successReason = successMatcher.group(1).trim();
             log.info("Success reason: {}", successReason);
         }
-        
+
         // Extract failure_reason
         Pattern failurePattern = Pattern.compile("failure_reason\\s*:\\s*(.+?)(?=\\n|$)", Pattern.CASE_INSENSITIVE);
         Matcher failureMatcher = failurePattern.matcher(response);
@@ -588,7 +599,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             failureReason = failureMatcher.group(1).trim();
             log.info("Failure reason: {}", failureReason);
         }
-        
+
         return VerificationDto.builder()
                 .textResult(textResult)
                 .imageResult(imageResult)

--- a/src/main/java/com/example/trace/mission/service/DailyMissionService.java
+++ b/src/main/java/com/example/trace/mission/service/DailyMissionService.java
@@ -20,14 +20,15 @@ import com.example.trace.post.dto.post.PostDto;
 import com.example.trace.post.service.PostService;
 import com.example.trace.user.User;
 import com.example.trace.user.UserService;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -141,7 +142,7 @@ public class DailyMissionService {
         DailyMission assignedDailyMission = dailyMissionRepository.findByUserAndCreatedAt(user, missionDate)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.DAILYMISSION_NOT_FOUND));
 
-        VerificationDto verificationDto = postVerificationService.verifyDailyMission(submitDto, assignedDailyMission);
+        VerificationDto verificationDto = postVerificationService.verifyDailyMission(submitDto, assignedDailyMission, providerId);
         if (!verificationDto.isImageResult() && !verificationDto.isTextResult()) {
             throw new MissionException(MissionErrorCode.VERIFICATION_FAIL);
         }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### 선행 인증 횟수 저장 방법

- Redis 사용
- 새로운 엔티티 추가하여 횟수 관리

위 두 가지 방법이 있다.

새로운 엔티티를 추가하면, 24시간이 지날 때마다 스케줄러를 사용하여 삭제하는 과정이 필요하다.

1. 신규 엔티티 추가, 스케줄러도 필요 -> 복잡도 증가.
2. db의 쿼리 조회,쓰기 성능이 redis보다 떨어짐

위와 같은 이유로 Redis를 사용하는게 좋을 것 같다고 생각한다.
Redis는 임시 회원가입 토큰과 리프레시 토큰 저장 시 사용하고 있으므로 인프라는 갖춰져 있어서 바로 사용 가능하다.

## 2. ✨새롭게 변경된 점

- 하루에 선행 인증 시도 횟수를 10회 초과할 시, 예외 처리

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
