### PR TITLE
[FEATURE] 게시글 글자수를 800자로 제한

### DIFF
--- a/src/main/java/com/example/trace/global/errorcode/PostErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/PostErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum PostErrorCode implements ErrorCode{
+public enum PostErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     POST_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 이미지 업로드에 실패했습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
@@ -17,10 +17,11 @@ public enum PostErrorCode implements ErrorCode{
     TITLE_EMPTY(HttpStatus.BAD_REQUEST, "제목이 비어있습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "댓글 삭제 권한이 없습니다."),
-    INVALID_KEYWORD_LENGTH(HttpStatus.BAD_REQUEST,"검색어는 두 글자 이상이어야 합니다."),
-    KEYWORD_TOO_LONG(HttpStatus.BAD_REQUEST,"검색어는 50글자 이내여야 합니다."),
-    INVALID_KEYWORD(HttpStatus.BAD_REQUEST,"검색어는 특수문자로만 이루어지면 안됩니다.")
-    ;
+    INVALID_KEYWORD_LENGTH(HttpStatus.BAD_REQUEST, "검색어는 두 글자 이상이어야 합니다."),
+    KEYWORD_TOO_LONG(HttpStatus.BAD_REQUEST, "검색어는 50글자 이내여야 합니다."),
+    INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "검색어는 특수문자로만 이루어지면 안됩니다."),
+    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "게시글 내용은 800자를 초과할 수 없습니다.");
+
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/example/trace/global/exception/PostException.java
+++ b/src/main/java/com/example/trace/global/exception/PostException.java
@@ -2,11 +2,15 @@ package com.example.trace.global.exception;
 
 import com.example.trace.global.errorcode.PostErrorCode;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 
 @Getter
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class PostException extends RuntimeException {
     private final PostErrorCode postErrorCode;
+
     public PostException(PostErrorCode postErrorCode) {
         super(postErrorCode.getMessage());
         this.postErrorCode = postErrorCode;

--- a/src/main/java/com/example/trace/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/trace/global/handler/GlobalExceptionHandler.java
@@ -1,11 +1,25 @@
 package com.example.trace.global.handler;
 
-import com.example.trace.global.errorcode.*;
-import com.example.trace.global.exception.*;
+import com.example.trace.global.errorcode.AuthErrorCode;
+import com.example.trace.global.errorcode.ErrorCode;
+import com.example.trace.global.errorcode.FileErrorCode;
+import com.example.trace.global.errorcode.GptErrorCode;
+import com.example.trace.global.errorcode.MissionErrorCode;
+import com.example.trace.global.errorcode.PostErrorCode;
+import com.example.trace.global.errorcode.ReportErrorCode;
+import com.example.trace.global.errorcode.SignUpErrorCode;
+import com.example.trace.global.errorcode.TokenErrorCode;
+import com.example.trace.global.exception.AuthException;
+import com.example.trace.global.exception.FileException;
+import com.example.trace.global.exception.GptException;
+import com.example.trace.global.exception.MissionException;
+import com.example.trace.global.exception.PostException;
+import com.example.trace.global.exception.ReportException;
+import com.example.trace.global.exception.SignUpException;
+import com.example.trace.global.exception.TokenException;
 import com.example.trace.global.response.ErrorResponse;
 import com.example.trace.global.response.GptErrorResponse;
 import com.example.trace.global.response.TokenErrorResponse;
-import com.example.trace.report.domain.Report;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,93 +28,68 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(TokenException.class)
-    public ResponseEntity<Object> handleTokenException(TokenException e) {
+    public ResponseEntity<TokenErrorResponse> handleTokenException(TokenException e) {
         TokenErrorCode tokenErrorCode = e.getTokenErrorCode();
         return handleExceptionInternal(tokenErrorCode);
     }
 
     @ExceptionHandler(AuthException.class)
-    public ResponseEntity<Object> handleAuthException(AuthException e) {
+    public ResponseEntity<ErrorResponse> handleAuthException(AuthException e) {
         AuthErrorCode authErrorCode = e.getAuthErrorCode();
         return handleExceptionInternal(authErrorCode);
     }
+
     @ExceptionHandler(MissionException.class)
-    public ResponseEntity<Object> handleMissionException(MissionException e) {
+    public ResponseEntity<ErrorResponse> handleMissionException(MissionException e) {
         MissionErrorCode missionErrorCode = e.getMissionErrorCode();
         return handleExceptionInternal(missionErrorCode);
     }
 
 
     @ExceptionHandler(SignUpException.class)
-    public ResponseEntity<Object> handleSignUpException(SignUpException e) {
+    public ResponseEntity<ErrorResponse> handleSignUpException(SignUpException e) {
         SignUpErrorCode signUpErrorCode = e.getSignUpErrorCode();
         return handleExceptionInternal(signUpErrorCode);
     }
 
     @ExceptionHandler(FileException.class)
-    public ResponseEntity<Object> handleAuthException(FileException e) {
+    public ResponseEntity<ErrorResponse> handleAuthException(FileException e) {
         FileErrorCode fileErrorCode = e.getFileErrorCode();
         return handleExceptionInternal(fileErrorCode);
     }
 
     @ExceptionHandler(PostException.class)
-    public ResponseEntity<Object> handleAuthException(PostException e) {
+    public ResponseEntity<ErrorResponse> handleAuthException(PostException e) {
         PostErrorCode postErrorCode = e.getPostErrorCode();
         return handleExceptionInternal(postErrorCode);
     }
+
     @ExceptionHandler(ReportException.class)
-    public ResponseEntity<Object> handleAuthException(ReportException e) {
+    public ResponseEntity<ErrorResponse> handleAuthException(ReportException e) {
         ReportErrorCode reportErrorCode = e.getReportErrorCode();
         return handleExceptionInternal(reportErrorCode);
     }
 
-
-
     @ExceptionHandler(GptException.class)
-    public ResponseEntity<Object> handleGptException(GptException e) {
+    public ResponseEntity<GptErrorResponse> handleGptException(GptException e) {
         GptErrorCode gptErrorCode = e.getGptErrorCode();
         String failureReason = e.getFailureReason();
-        return handleExceptionInternal(gptErrorCode,failureReason);
+        return handleExceptionInternal(gptErrorCode, failureReason);
     }
 
-    private ResponseEntity<Object> handleExceptionInternal(TokenErrorCode tokenErrorCode) {
+    private ResponseEntity<ErrorResponse> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ResponseEntity<TokenErrorResponse> handleExceptionInternal(TokenErrorCode tokenErrorCode) {
         return ResponseEntity.status(tokenErrorCode.getHttpStatus())
                 .body(makeTokenErrorResponse(tokenErrorCode));
     }
 
-    private ResponseEntity<Object> handleExceptionInternal(AuthErrorCode authErrorCode) {
-        return ResponseEntity.status(authErrorCode.getHttpStatus())
-                .body(makeErrorResponse(authErrorCode));
-    }
-
-    private ResponseEntity<Object> handleExceptionInternal(MissionErrorCode missionErrorCode) {
-        return ResponseEntity.status(missionErrorCode.getHttpStatus())
-                .body(makeErrorResponse(missionErrorCode));
-    }
-
-    private ResponseEntity<Object> handleExceptionInternal(SignUpErrorCode signUpErrorCode) {
-        return ResponseEntity.status(signUpErrorCode.getHttpStatus())
-                .body(makeErrorResponse(signUpErrorCode));
-    }
-
-    private ResponseEntity<Object> handleExceptionInternal(FileErrorCode fileErrorCode) {
-        return ResponseEntity.status(fileErrorCode.getHttpStatus())
-                .body(makeErrorResponse(fileErrorCode));
-    }
-
-    private ResponseEntity<Object> handleExceptionInternal(PostErrorCode postErrorCode) {
-        return ResponseEntity.status(postErrorCode.getHttpStatus())
-                .body(makeErrorResponse(postErrorCode));
-    }
-
-    private ResponseEntity<Object> handleExceptionInternal(GptErrorCode gptErrorCode, String failureReason) {
+    private ResponseEntity<GptErrorResponse> handleExceptionInternal(GptErrorCode gptErrorCode, String failureReason) {
         return ResponseEntity.status(gptErrorCode.getHttpStatus())
-                .body(makeGptErrorResponse(gptErrorCode,failureReason));
-    }
-
-    private ResponseEntity<Object> handleExceptionInternal(ReportErrorCode reportErrorCode) {
-        return ResponseEntity.status(reportErrorCode.getHttpStatus())
-                .body(makeErrorResponse(reportErrorCode));
+                .body(makeGptErrorResponse(gptErrorCode, failureReason));
     }
 
     private TokenErrorResponse makeTokenErrorResponse(TokenErrorCode tokenErrorCode) {
@@ -119,12 +108,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .failureReason(failureReason)
                 .build();
     }
+
     private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
                 .code(errorCode.name())
                 .message(errorCode.getMessage())
                 .build();
     }
-
-
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
게시글의 글자수를 800자로 제한합니다.

## 2. ✨새롭게 변경된 점
- `Post` 엔티티의 생성자를 명시적으로 작성하여 content의 길이를 확인할 수 있도록 변경
- `GlobalExceptionHandler`의 중복되는 메서드를 통합
  - 매개변수에서 ErrorCode를 받도록 변경하였씁니다

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
