### PR TITLE
알림을 삭제하는 API 추가

### DIFF
--- a/src/main/java/com/example/trace/global/errorcode/NotificationErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/NotificationErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.trace.global.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
+    NOTIFICATION_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "알림을 삭제할 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/trace/global/exception/NotificationException.java
+++ b/src/main/java/com/example/trace/global/exception/NotificationException.java
@@ -1,0 +1,14 @@
+package com.example.trace.global.exception;
+
+import com.example.trace.global.errorcode.NotificationErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotificationException extends RuntimeException {
+    private final NotificationErrorCode notificationErrorCode;
+
+    public NotificationException(NotificationErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.notificationErrorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/trace/global/fcm/FcmTokenNotificationService.java
+++ b/src/main/java/com/example/trace/global/fcm/FcmTokenNotificationService.java
@@ -3,6 +3,7 @@ package com.example.trace.global.fcm;
 import static com.example.trace.global.errorcode.TokenErrorCode.NOT_FOUND_FCM_TOKEN;
 
 import com.example.trace.global.exception.TokenException;
+import com.example.trace.notification.domain.NotificationEvent.NotificationData;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -29,8 +30,8 @@ public class FcmTokenNotificationService {
     /**
      * Data-only 메시지 전송 (notification 필드 사용 안함)
      */
-    public Map<String, String> sendDataOnlyMessage(String providerId, String title, String body,
-                                                   Map<String, String> additionalData) {
+    public NotificationData sendDataOnlyMessage(String providerId, String title, String body,
+                                                NotificationData data) {
         Optional<String> tokenOpt = fcmTokenService.getTokenByProviderId(providerId);
 
         if (tokenOpt.isEmpty()) {
@@ -41,19 +42,13 @@ public class FcmTokenNotificationService {
         String token = tokenOpt.get();
 
         // Data-only 메시지 구성 (notification 필드 없음)
-        Map<String, String> data = new HashMap<>();
-        data.put("title", title);
-        data.put("body", body);
-        data.put("timestamp", String.valueOf(System.currentTimeMillis()));
-
-        // 추가 데이터가 있으면 포함
-        if (additionalData != null) {
-            data.putAll(additionalData);
-        }
+        data.setTitle(title);
+        data.setBody(body);
+        data.setTimestamp(String.valueOf(System.currentTimeMillis()));
 
         Message message = Message.builder()
                 .setToken(token)
-                .putAllData(data)  // notification 필드 대신 data 필드만 사용
+                .putAllData(data.toMap())  // notification 필드 대신 data 필드만 사용
                 .build();
 
         log.info("fcm 알림 보내는 중..");

--- a/src/main/java/com/example/trace/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/trace/global/handler/GlobalExceptionHandler.java
@@ -1,11 +1,27 @@
 package com.example.trace.global.handler;
 
-import com.example.trace.global.errorcode.*;
-import com.example.trace.global.exception.*;
+import com.example.trace.global.errorcode.AuthErrorCode;
+import com.example.trace.global.errorcode.ErrorCode;
+import com.example.trace.global.errorcode.FileErrorCode;
+import com.example.trace.global.errorcode.GptErrorCode;
+import com.example.trace.global.errorcode.MissionErrorCode;
+import com.example.trace.global.errorcode.NotificationErrorCode;
+import com.example.trace.global.errorcode.PostErrorCode;
+import com.example.trace.global.errorcode.ReportErrorCode;
+import com.example.trace.global.errorcode.SignUpErrorCode;
+import com.example.trace.global.errorcode.TokenErrorCode;
+import com.example.trace.global.exception.AuthException;
+import com.example.trace.global.exception.FileException;
+import com.example.trace.global.exception.GptException;
+import com.example.trace.global.exception.MissionException;
+import com.example.trace.global.exception.NotificationException;
+import com.example.trace.global.exception.PostException;
+import com.example.trace.global.exception.ReportException;
+import com.example.trace.global.exception.SignUpException;
+import com.example.trace.global.exception.TokenException;
 import com.example.trace.global.response.ErrorResponse;
 import com.example.trace.global.response.GptErrorResponse;
 import com.example.trace.global.response.TokenErrorResponse;
-import com.example.trace.report.domain.Report;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,6 +29,13 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(NotificationException.class)
+    public ResponseEntity<ErrorResponse> handleNotificationException(NotificationException e) {
+        NotificationErrorCode notificationErrorCode = e.getNotificationErrorCode();
+        return handleExceptionInternal(notificationErrorCode);
+    }
+
     @ExceptionHandler(TokenException.class)
     public ResponseEntity<Object> handleTokenException(TokenException e) {
         TokenErrorCode tokenErrorCode = e.getTokenErrorCode();
@@ -24,6 +47,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         AuthErrorCode authErrorCode = e.getAuthErrorCode();
         return handleExceptionInternal(authErrorCode);
     }
+
     @ExceptionHandler(MissionException.class)
     public ResponseEntity<Object> handleMissionException(MissionException e) {
         MissionErrorCode missionErrorCode = e.getMissionErrorCode();
@@ -48,6 +72,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         PostErrorCode postErrorCode = e.getPostErrorCode();
         return handleExceptionInternal(postErrorCode);
     }
+
     @ExceptionHandler(ReportException.class)
     public ResponseEntity<Object> handleAuthException(ReportException e) {
         ReportErrorCode reportErrorCode = e.getReportErrorCode();
@@ -55,12 +80,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
 
-
     @ExceptionHandler(GptException.class)
     public ResponseEntity<Object> handleGptException(GptException e) {
         GptErrorCode gptErrorCode = e.getGptErrorCode();
         String failureReason = e.getFailureReason();
-        return handleExceptionInternal(gptErrorCode,failureReason);
+        return handleExceptionInternal(gptErrorCode, failureReason);
+    }
+
+    private ResponseEntity<ErrorResponse> handleExceptionInternal(NotificationErrorCode notificationErrorCode) {
+        return ResponseEntity.status(notificationErrorCode.getHttpStatus())
+                .body(makeErrorResponse(notificationErrorCode));
     }
 
     private ResponseEntity<Object> handleExceptionInternal(TokenErrorCode tokenErrorCode) {
@@ -95,7 +124,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> handleExceptionInternal(GptErrorCode gptErrorCode, String failureReason) {
         return ResponseEntity.status(gptErrorCode.getHttpStatus())
-                .body(makeGptErrorResponse(gptErrorCode,failureReason));
+                .body(makeGptErrorResponse(gptErrorCode, failureReason));
     }
 
     private ResponseEntity<Object> handleExceptionInternal(ReportErrorCode reportErrorCode) {
@@ -119,6 +148,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .failureReason(failureReason)
                 .build();
     }
+
     private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
                 .code(errorCode.name())

--- a/src/main/java/com/example/trace/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/trace/notification/controller/NotificationController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -39,8 +40,17 @@ public class NotificationController {
 
     @PutMapping("/open/{id}")
     @Operation(summary = "알림 읽기", description = "알림을 읽을 때 호출됩니다.")
-    public ResponseEntity<?> read(@PathVariable("id") Long id, @AuthenticationPrincipal PrincipalDetails current) {
-        notificationService.read(id, current.getUser().getProviderId());
+    public ResponseEntity<?> read(@PathVariable("id") Long notificationId,
+                                  @AuthenticationPrincipal PrincipalDetails current) {
+        notificationService.read(notificationId, current.getUser().getProviderId());
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "알림 삭제", description = "알림을 삭제하며 이는 되돌릴 수 없습니다.")
+    public ResponseEntity<?> delete(@PathVariable("id") Long notificationId,
+                                    @AuthenticationPrincipal PrincipalDetails current) {
+        notificationService.delete(notificationId, current.getUser().getProviderId());
+        return ResponseEntity.ok("삭제되었습니다.");
     }
 }

--- a/src/main/java/com/example/trace/notification/domain/NotificationEvent.java
+++ b/src/main/java/com/example/trace/notification/domain/NotificationEvent.java
@@ -18,6 +18,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -76,15 +77,36 @@ public class NotificationEvent implements Comparable<NotificationEvent> {
         return true;
     }
 
+    //TODO: sourceType에 따라 refId 할당
+    public NotificationEvent read() {
+        isRead = true;
+        return this;
+    }
+
+    public boolean isOwner(String providerId) {
+        return this.user.getProviderId().equals(providerId);
+    }
+
     @Override
     public int compareTo(@NotNull NotificationEvent o) {
         return this.createdAt.compareTo(o.createdAt);
     }
 
-    //TODO: sourceType에 따라 refId 할당
-    public NotificationEvent read() {
-        isRead = true;
-        return this;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof NotificationEvent)) {
+            return false;
+        }
+        NotificationEvent that = (NotificationEvent) o;
+        return this.id != null && this.id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     /**

--- a/src/main/java/com/example/trace/notification/domain/NotificationEvent.java
+++ b/src/main/java/com/example/trace/notification/domain/NotificationEvent.java
@@ -1,7 +1,13 @@
 package com.example.trace.notification.domain;
 
+import com.example.trace.emotion.EmotionType;
 import com.example.trace.user.User;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Converter;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -10,10 +16,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 @Entity
@@ -37,7 +46,8 @@ public class NotificationEvent implements Comparable<NotificationEvent> {
 
     // data 메시지인 경우 json 직렬화해서 저장
     @Column(columnDefinition = "TEXT")
-    private String data;
+    @Convert(converter = NotificationDataConverter.class)
+    private NotificationData data;
 
     private Long createdAt;
 
@@ -75,5 +85,75 @@ public class NotificationEvent implements Comparable<NotificationEvent> {
     public NotificationEvent read() {
         isRead = true;
         return this;
+    }
+
+    /**
+     * Notification의 data 필으데 직렬화되어 저장될 구조체
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class NotificationData {
+        private String title;
+        private String body;
+        private SourceType type;
+        private Long postId;
+        private EmotionType emotion;
+        private String timestamp;
+
+        public Map<String, String> toMap() {
+            Map<String, String> map = new HashMap<>();
+            if (title != null) {
+                map.put("title", title);
+            }
+            if (body != null) {
+                map.put("body", body);
+            }
+            if (type != null) {
+                map.put("type", type.name());
+            }
+            if (postId != null) {
+                map.put("postId", postId.toString());
+            }
+            if (emotion != null) {
+                map.put("emotion", emotion.name());
+            }
+            if (timestamp != null) {
+                map.put("timestamp", timestamp);
+            }
+            return map;
+        }
+    }
+
+    @Converter
+    public static class NotificationDataConverter implements AttributeConverter<NotificationData, String> {
+
+        private static final ObjectMapper objectMapper = new ObjectMapper();
+
+        @Override
+        public String convertToDatabaseColumn(NotificationData attribute) {
+            if (attribute == null) {
+                return null;
+            }
+            try {
+                return objectMapper.writeValueAsString(attribute);
+            } catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("NotificationData 직렬화 실패", e);
+            }
+        }
+
+        @Override
+        public NotificationData convertToEntityAttribute(String dbData) {
+            if (dbData == null || dbData.isEmpty()) {
+                return null;
+            }
+            try {
+                return objectMapper.readValue(dbData, NotificationData.class);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("NotificationData 역직렬화 실패", e);
+            }
+        }
     }
 }

--- a/src/test/java/com/example/trace/global/fcm/NotificationEventServiceTest.java
+++ b/src/test/java/com/example/trace/global/fcm/NotificationEventServiceTest.java
@@ -5,12 +5,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.example.trace.mission.mission.Mission;
+import com.example.trace.notification.domain.NotificationEvent.NotificationData;
 import com.example.trace.notification.repository.NotificationEventRepository;
 import com.example.trace.notification.service.NotificationEventService;
 import com.example.trace.user.User;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,9 +57,9 @@ class NotificationEventServiceTest {
         when(fcmTokenService.getTokenByProviderId(providerId)).thenReturn(Optional.of("token"));
         when(firebaseMessaging.send(any(Message.class))).thenReturn("response");
 
-        Map<String, String> sentData = notificationEventService.sendDailyMissionAssignedNotification(user, mission);
+        NotificationData sentData = notificationEventService.sendDailyMissionAssignedNotification(user, mission);
 
         //then
-        assertEquals(mission.getDescription(), sentData.get("body"));
+        assertEquals(mission.getDescription(), sentData.getBody());
     }
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
알림을 삭제하는 기능을 개발하였습니다. 삭제된 알림은 복구할 수 없습니다.
`orphanRemoval`을 사용하였고 `List<NotificationEvent>`의 요소를 remove하여 DB뿐만 아니라 객체 상태도 동기화되도록 구현하였습니다.

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
