### PR TITLE
Feature/jiseob/#35

### DIFF
--- a/src/main/java/com/example/trace/TraceApplication.java
+++ b/src/main/java/com/example/trace/TraceApplication.java
@@ -3,22 +3,25 @@ package com.example.trace;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
+@EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 @EnableFeignClients
 public class TraceApplication {
 
-	static {
-		// JVM 시작 시점에 시간대 설정
-		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-		System.setProperty("user.timezone", "Asia/Seoul");
-	}
-	public static void main(String[] args) {
-		SpringApplication.run(TraceApplication.class, args);
-	}
+    static {
+        // JVM 시작 시점에 시간대 설정
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        System.setProperty("user.timezone", "Asia/Seoul");
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(TraceApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/example/trace/report/service/UserBlockService.java
+++ b/src/main/java/com/example/trace/report/service/UserBlockService.java
@@ -73,5 +73,13 @@ public class UserBlockService {
         return userBlockRepository.findByBlockerAndBlocked(blocker, blocked).isPresent();
     }
 
+    @Transactional(readOnly = true)
+    public UserBlock getUserBlock(String blockerProviderId, String blockedProviderId) {
+        User blocker = userService.getUser(blockerProviderId);
+        User blocked = userService.getUser(blockedProviderId);
+        return userBlockRepository.findByBlockerAndBlocked(blocker, blocked)
+                .orElseThrow(() -> new IllegalArgumentException("차단된 사용자가 아닙니다."));
+    }
+
 
 }

--- a/src/main/java/com/example/trace/report/service/UserBlockService.java
+++ b/src/main/java/com/example/trace/report/service/UserBlockService.java
@@ -1,16 +1,18 @@
 package com.example.trace.report.service;
 
 import com.example.trace.auth.repository.UserRepository;
+import com.example.trace.global.exception.UserException;
 import com.example.trace.report.domain.UserBlock;
 import com.example.trace.report.dto.BlockedUserDto;
 import com.example.trace.report.repository.UserBlockRepository;
 import com.example.trace.user.User;
-import com.example.trace.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.example.trace.global.errorcode.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +20,6 @@ public class UserBlockService {
 
     private final UserRepository userRepository;
     private final UserBlockRepository userBlockRepository;
-    private final UserService userService;
 
     public void blockUser(String blockerProviderId, String blockedProviderId) {
         if (blockerProviderId.equals(blockedProviderId)) {
@@ -68,17 +69,11 @@ public class UserBlockService {
 
     @Transactional(readOnly = true)
     public boolean isBlocked(String blockerProviderId, String blockedProviderId) {
-        User blocker = userService.getUser(blockerProviderId);
-        User blocked = userService.getUser(blockedProviderId);
+        User blocker = userRepository.findByProviderId(blockerProviderId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+        User blocked = userRepository.findByProviderId(blockedProviderId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
         return userBlockRepository.findByBlockerAndBlocked(blocker, blocked).isPresent();
-    }
-
-    @Transactional(readOnly = true)
-    public UserBlock getUserBlock(String blockerProviderId, String blockedProviderId) {
-        User blocker = userService.getUser(blockerProviderId);
-        User blocked = userService.getUser(blockedProviderId);
-        return userBlockRepository.findByBlockerAndBlocked(blocker, blocked)
-                .orElseThrow(() -> new IllegalArgumentException("차단된 사용자가 아닙니다."));
     }
 
 

--- a/src/main/java/com/example/trace/user/UserService.java
+++ b/src/main/java/com/example/trace/user/UserService.java
@@ -1,8 +1,6 @@
 package com.example.trace.user;
 
 
-import static com.example.trace.global.errorcode.UserErrorCode.USER_NOT_FOUND;
-
 import com.example.trace.auth.Util.JwtUtil;
 import com.example.trace.auth.Util.RedisUtil;
 import com.example.trace.auth.repository.UserRepository;
@@ -10,18 +8,25 @@ import com.example.trace.global.errorcode.TokenErrorCode;
 import com.example.trace.global.errorcode.UserErrorCode;
 import com.example.trace.global.exception.TokenException;
 import com.example.trace.global.exception.UserException;
+import com.example.trace.report.domain.UserBlock;
+import com.example.trace.report.service.UserBlockService;
+import com.example.trace.user.dto.BlockedUserProfileDto;
 import com.example.trace.user.dto.UpdateNickNameRequest;
 import com.example.trace.user.dto.UserDto;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.example.trace.global.errorcode.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final UserBlockService userBlockService;
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
 
@@ -32,6 +37,14 @@ public class UserService {
         User user = userRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
         return UserDto.fromEntity(user);
+    }
+
+    public BlockedUserProfileDto getBlockedUserProfile(String currentUserProviderId, String targetProviderId) {
+        // 차단 정보 조회
+        User targetUser = getUser(targetProviderId);
+        UserBlock userBlcok = userBlockService.getUserBlock(currentUserProviderId, targetProviderId);
+        // 차단된 사용자 프로필 정보 반환
+        return BlockedUserProfileDto.fromEntity(targetUser, userBlcok.getCreatedAt());
     }
 
     public User getUser(String providerId) {

--- a/src/main/java/com/example/trace/user/dto/BlockedUserProfileDto.java
+++ b/src/main/java/com/example/trace/user/dto/BlockedUserProfileDto.java
@@ -1,0 +1,39 @@
+package com.example.trace.user.dto;
+
+import com.example.trace.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "차단된 사용자 프로필 정보")
+public class BlockedUserProfileDto {
+
+    @Schema(description = "사용자 providerId")
+    private String providerId;
+
+    @Schema(description = "닉네임")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImageUrl;
+
+    @Schema(description = "차단한 날짜")
+    private LocalDateTime blockedAt;
+
+    public static BlockedUserProfileDto fromEntity(User user, LocalDateTime blockedAt) {
+        return BlockedUserProfileDto.builder()
+                .providerId(user.getProviderId())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .blockedAt(blockedAt)
+                .build();
+    }
+}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### DTO 재활용

기존 사용자 프로필 조회 dto를 재활용할까 생각을 했지만,
단일 책임 원칙을 위해 dto를 새로 생성하였다. 

api는 동일하지만, 차단 여부를 확인한 뒤 분기시켰다.

### SRP 오개념

단일 책임 원칙에 대한 오개념 때문에

다른 도메인의 repository를 서비스에서 사용하지 않으려는 습관이 있어서

각 서비스에서 데이터 조회하는 메서드를 만들어 repository 대신 service 계층을 사용하도록 했다.

그 결과, `userService`와 `userBlockService `사이에 순환 참조가 발생하였다.

repository는 단순 데이터 접근, service는 비즈니스 로직을 담당하기만하면 원칙은 지켜진다.

### @CreatedDate 정상 작동을 위해서

ec2 서버 시간대가 UTC 라서 저번 작업 시에 `@CreatedDateTime` 의 시간대가 8시간인가 밀렸던 적이 있다.

그래서 @PrePersist 를 이용하여 명시적으로 시간대를 설정했는데 이번에는 차단 시간을 처리하기 위해서 

비슷한 작업이 필요했다. 하지만 이번에는 `@EnableJpaAuditing`, `@EntityListeners(AuditingEntityListener.class)` 등을 

사용해서 시간대가 제대로 찍히는지 확인할 예정이다. 그래도 안된다면 이슈를 새로 생성하여 수정할 계획이다.



## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

SOLID 원칙을 어디선가 주워들어서 그냥 내 멋대로 오해하고 코드를 작성했다.

분명하게 배운 것이 아니라면 굳이 생각하지 말자.



