### PR TITLE
PostImage에 양방향 연관관계를 올바르게 설정

### DIFF
--- a/src/main/java/com/example/trace/post/domain/PostImage.java
+++ b/src/main/java/com/example/trace/post/domain/PostImage.java
@@ -53,9 +53,10 @@ public class PostImage {
      *
      * @param imageUrls: s3에 저장된 이미지 url list
      */
-    public static List<PostImage> listOf(List<String> imageUrls) {
+    public static List<PostImage> listOf(List<String> imageUrls, Post post) {
         return imageUrls.stream()
                 .map(url -> PostImage.builder()
+                        .post(post)
                         .imageUrl(url)
                         .build())
                 .toList();

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -273,7 +273,7 @@ public class PostServiceImpl implements PostService {
             try {
                 // 추가할 이미지를 s3에 업로드 후 이미지 링크들을 리스트로 받아옴
                 List<String> savedImageUrls = s3UploadService.savePostFiles(imageFiles, FileType.POST, providerId);
-                images = postImageRepository.saveAll(PostImage.listOf(savedImageUrls));
+                images = PostImage.listOf(savedImageUrls, post);
 
                 log.info("새로 업로드된 이미지 개수: {}, URL 목록: {}",
                         images.size(), images.stream().map(PostImage::getImageUrl).toList());


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
PostImage와 Post간 양방향 매핑을 설정함. 기존엔 Post -> PostImage로 매핑이 되어있었음

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
