### PR TITLE
인증 시 획득하는 포인트 양 변경

### DIFF
--- a/src/main/java/com/example/trace/gpt/dto/VerificationDto.java
+++ b/src/main/java/com/example/trace/gpt/dto/VerificationDto.java
@@ -1,5 +1,9 @@
 package com.example.trace.gpt.dto;
 
+import com.example.trace.global.errorcode.GptErrorCode;
+import com.example.trace.global.exception.GptException;
+import com.example.trace.gpt.domain.Verification;
+import com.example.trace.post.domain.PostType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +16,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Schema(description = "게시물 선행 인증 결과")
 public class VerificationDto {
+    @Schema(description = "게시글 종류", example = "MISSION, GOOD_DEED")
+    private PostType postType;
     @Schema(description = "텍스트 인증 결과", example = "true")
     private boolean textResult;
     @Schema(description = "이미지 인증 결과", example = "true")
@@ -21,7 +27,6 @@ public class VerificationDto {
     @Schema(description = "인증 실패 이유", example = "null")
     private String failureReason;
 
-
     public static VerificationDto textOnlyFailure(String reason) {
         return VerificationDto.builder()
                 .textResult(false)
@@ -30,12 +35,23 @@ public class VerificationDto {
                 .build();
     }
 
-
     public static VerificationDto bothFailure(String reason) {
         return VerificationDto.builder()
                 .textResult(false)
                 .imageResult(false)
                 .failureReason(reason)
+                .build();
+    }
+
+    public Verification toEntity() {
+        if (!textResult && imageResult) {
+            throw new GptException(GptErrorCode.GPT_LOGIC_ERROR, null);
+        }
+        return Verification.builder()
+                .isTextVerified(textResult)
+                .isImageVerified(imageResult)
+                .failureReason(failureReason)
+                .successReason(successReason)
                 .build();
     }
 } 

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
@@ -2,12 +2,11 @@ package com.example.trace.gpt.service;
 
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
-import com.example.trace.mission.mission.DailyMission;
 import com.example.trace.post.dto.post.PostCreateDto;
 
 public interface PostVerificationService {
     VerificationDto verifyPost(PostCreateDto postCreateDto, String providerId);
 
-    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, DailyMission assignedDailyMission,
+    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, String missionContent,
                                        String providerId);
 } 

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
@@ -1,6 +1,5 @@
 package com.example.trace.gpt.service;
 
-import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.mission.mission.DailyMission;
@@ -9,7 +8,6 @@ import com.example.trace.post.dto.post.PostCreateDto;
 public interface PostVerificationService {
     VerificationDto verifyPost(PostCreateDto postCreateDto, String providerId);
 
-    Verification makeVerification(VerificationDto verificationDto);
-
-    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, DailyMission assignedDailyMission, String providerId);
+    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, DailyMission assignedDailyMission,
+                                       String providerId);
 } 

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -85,16 +85,16 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                 throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
             }
             return result;
-        } else {
-            VerificationDto result = verifyMissionTextAndImages(requestContent, missionContent, images);
-
-            if (!result.isTextResult() || !result.isImageResult()) {
-                String failureReason = result.getFailureReason();
-                log.info("실패 이유 : {}", failureReason);
-                throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
-            }
-            return result;
         }
+        VerificationDto result = verifyMissionTextAndImages(requestContent, missionContent, images);
+
+        if (!result.isTextResult() || !result.isImageResult()) {
+            String failureReason = result.getFailureReason();
+            log.info("실패 이유 : {}", failureReason);
+            throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
+        }
+        return result;
+
     }
 
     @Override

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -6,7 +6,6 @@ import com.example.trace.global.errorcode.GptErrorCode;
 import com.example.trace.global.errorcode.PostErrorCode;
 import com.example.trace.global.exception.GptException;
 import com.example.trace.global.exception.PostException;
-import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.mission.mission.DailyMission;
@@ -17,6 +16,15 @@ import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.completion.chat.ChatMessageRole;
 import com.theokanning.openai.service.OpenAiService;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,12 +35,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -63,7 +65,8 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         }
     }
 
-    public VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, DailyMission assignedDailyMission, String providerId) {
+    public VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, DailyMission assignedDailyMission,
+                                              String providerId) {
 
         if (submitDto.getContent() == null || submitDto.getContent().isEmpty()) {
             throw new PostException(PostErrorCode.CONTENT_EMPTY);
@@ -73,7 +76,6 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         }
 
         checkAndIncrementDailyVerificationCount(providerId);
-
 
         String requestContent = submitDto.getContent();
         List<MultipartFile> images = submitDto.getImageFiles();
@@ -138,45 +140,15 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         }
     }
 
-    public Verification makeVerification(VerificationDto verificationDto) {
-        if (verificationDto.isTextResult() && verificationDto.isImageResult()) {
-            Verification verification = Verification.builder()
-                    .isTextVerified(true)
-                    .isImageVerified(true)
-                    .failureReason(verificationDto.getFailureReason())
-                    .successReason(verificationDto.getSuccessReason())
-                    .build();
-            return verification;
-        } else if (verificationDto.isTextResult() && !verificationDto.isImageResult()) {
-            Verification verification = Verification.builder()
-                    .isTextVerified(true)
-                    .isImageVerified(false)
-                    .failureReason(verificationDto.getFailureReason())
-                    .successReason(verificationDto.getSuccessReason())
-                    .build();
-            return verification;
-        } else if (!verificationDto.isTextResult() && !verificationDto.isImageResult()) {
-            Verification verification = Verification.builder()
-                    .isTextVerified(false)
-                    .isImageVerified(false)
-                    .failureReason(verificationDto.getFailureReason())
-                    .successReason(verificationDto.getSuccessReason())
-                    .build();
-            return verification;
-        } else {
-            throw new GptException(GptErrorCode.GPT_LOGIC_ERROR, null);
-        }
-    }
-
-
     private VerificationDto verifyTextOnly(String content) {
         List<ChatMessage> messages = new ArrayList<>();
 
-        String systemPrompt = "You are an AI assistant tasked with verifying if the given text describes an act of kindness. " +
-                "Respond in the following format exactly:\n" +
-                "text_result: true/false\n" +
-                "success_reason: [reason for success, only if text_result is true]\n" +
-                "failure_reason: [reason for failure, only if text_result is false]";
+        String systemPrompt =
+                "You are an AI assistant tasked with verifying if the given text describes an act of kindness. " +
+                        "Respond in the following format exactly:\n" +
+                        "text_result: true/false\n" +
+                        "success_reason: [reason for success, only if text_result is true]\n" +
+                        "failure_reason: [reason for failure, only if text_result is false]";
 
         messages.add(new ChatMessage(ChatMessageRole.SYSTEM.value(), systemPrompt));
 
@@ -201,13 +173,14 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         try {
             List<ChatMessage> messages = new ArrayList<>();
 
-            String systemPrompt = "You are an AI assistant tasked with verifying if the given text describes an act of kindness " +
-                    "and if the provided images properly describe the text and relate to acts of kindness. " +
-                    "Respond in the following format exactly:\n" +
-                    "text_result: true/false\n" +
-                    "image_result: true/false\n" +
-                    "success_reason: [reason for success, only if any result is true]\n" +
-                    "failure_reason: [reason for failure, only if any result is false]";
+            String systemPrompt =
+                    "You are an AI assistant tasked with verifying if the given text describes an act of kindness " +
+                            "and if the provided images properly describe the text and relate to acts of kindness. " +
+                            "Respond in the following format exactly:\n" +
+                            "text_result: true/false\n" +
+                            "image_result: true/false\n" +
+                            "success_reason: [reason for success, only if any result is true]\n" +
+                            "failure_reason: [reason for failure, only if any result is false]";
 
             messages.add(new ChatMessage(ChatMessageRole.SYSTEM.value(), systemPrompt));
 
@@ -294,7 +267,8 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                         debugRequestBody = debugRequestBody.replaceAll(
                                 "(\"url\":\"data:image/jpeg;base64,)[^\"]+",
                                 "$1...[BASE64_DATA_LENGTH: " +
-                                        debugRequestBody.split("\"url\":\"data:image/jpeg;base64,")[1].split("\"")[0].length() +
+                                        debugRequestBody.split("\"url\":\"data:image/jpeg;base64,")[1].split(
+                                                "\"")[0].length() +
                                         "]..."
                         );
                     }
@@ -350,11 +324,13 @@ public class PostVerificationServiceImpl implements PostVerificationService {
     private VerificationDto verifyMissionTextOnly(String content, String missionDescription) {
         List<ChatMessage> messages = new ArrayList<>();
 
-        String systemPrompt = "You are an AI assistant tasked with verifying if the given submission is related to the assigned mission. " +
-                "Respond in the following format exactly:\n" +
-                "text_result: true/false\n" +
-                "success_reason: [reason for success, only if text_result is true]\n" +
-                "failure_reason: [reason for failure, only if text_result is false]";
+        String systemPrompt =
+                "You are an AI assistant tasked with verifying if the given submission is related to the assigned mission. "
+                        +
+                        "Respond in the following format exactly:\n" +
+                        "text_result: true/false\n" +
+                        "success_reason: [reason for success, only if text_result is true]\n" +
+                        "failure_reason: [reason for failure, only if text_result is false]";
 
         messages.add(new ChatMessage(ChatMessageRole.SYSTEM.value(), systemPrompt));
 
@@ -378,17 +354,20 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         }
     }
 
-    private VerificationDto verifyMissionTextAndImages(String content, String missionDescription, List<MultipartFile> images) {
+    private VerificationDto verifyMissionTextAndImages(String content, String missionDescription,
+                                                       List<MultipartFile> images) {
         try {
             List<ChatMessage> messages = new ArrayList<>();
 
-            String systemPrompt = "You are an AI assistant tasked with verifying if the given submission (both text and images) is related to the assigned mission. " +
-                    "Consider both the textual content and visual elements when making your assessment. " +
-                    "Respond in the following format exactly:\n" +
-                    "text_result: true/false\n" +
-                    "image_result: true/false\n" +
-                    "success_reason: [reason for success, only if any result is true]\n" +
-                    "failure_reason: [reason for failure, only if any result is false]";
+            String systemPrompt =
+                    "You are an AI assistant tasked with verifying if the given submission (both text and images) is related to the assigned mission. "
+                            +
+                            "Consider both the textual content and visual elements when making your assessment. " +
+                            "Respond in the following format exactly:\n" +
+                            "text_result: true/false\n" +
+                            "image_result: true/false\n" +
+                            "success_reason: [reason for success, only if any result is true]\n" +
+                            "failure_reason: [reason for failure, only if any result is false]";
 
             messages.add(new ChatMessage(ChatMessageRole.SYSTEM.value(), systemPrompt));
 
@@ -477,7 +456,8 @@ public class PostVerificationServiceImpl implements PostVerificationService {
                         debugRequestBody = debugRequestBody.replaceAll(
                                 "(\"url\":\"data:image/jpeg;base64,)[^\"]+",
                                 "$1...[BASE64_DATA_LENGTH: " +
-                                        debugRequestBody.split("\"url\":\"data:image/jpeg;base64,")[1].split("\"")[0].length() +
+                                        debugRequestBody.split("\"url\":\"data:image/jpeg;base64,")[1].split(
+                                                "\"")[0].length() +
                                         "]..."
                         );
                     }

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -10,7 +10,6 @@ import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.mission.mission.DailyMission;
 import com.example.trace.post.dto.post.PostCreateDto;
-import com.example.trace.user.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatMessage;
@@ -84,6 +83,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
 
         if (images == null || images.isEmpty()) {
             VerificationDto result = verifyMissionTextOnly(requestContent, assignedContent);
+
             if (!result.isTextResult()) {
                 String failureReason = result.getFailureReason();
                 log.info("실패 이유 : {}", failureReason);
@@ -92,6 +92,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             return result;
         } else {
             VerificationDto result = verifyMissionTextAndImages(requestContent, assignedContent, images);
+
             if (!result.isTextResult() || !result.isImageResult()) {
                 String failureReason = result.getFailureReason();
                 log.info("실패 이유 : {}", failureReason);
@@ -106,9 +107,6 @@ public class PostVerificationServiceImpl implements PostVerificationService {
 
     @Override
     public VerificationDto verifyPost(PostCreateDto postCreateDto, String providerId) {
-        User user = userRepository.findByProviderId(providerId)
-                .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
-
         checkAndIncrementDailyVerificationCount(providerId);
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {
@@ -124,6 +122,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         if (images == null || images.isEmpty()) {
             // Only text verification is needed
             VerificationDto result = verifyTextOnly(content);
+
             if (!result.isTextResult()) {
                 String failureReason = result.getFailureReason();
                 throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
@@ -132,6 +131,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
         } else {
             // Both text and image verification is needed
             VerificationDto result = verifyTextAndImages(content, images);
+
             if (!result.isTextResult() || !result.isImageResult()) {
                 String failureReason = result.getFailureReason();
                 throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -86,6 +86,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             }
             return result;
         }
+
         VerificationDto result = verifyMissionTextAndImages(requestContent, missionContent, images);
 
         if (!result.isTextResult() || !result.isImageResult()) {

--- a/src/main/java/com/example/trace/mission/controller/DailyMissionController.java
+++ b/src/main/java/com/example/trace/mission/controller/DailyMissionController.java
@@ -2,13 +2,17 @@ package com.example.trace.mission.controller;
 
 import com.example.trace.auth.dto.PrincipalDetails;
 import com.example.trace.global.response.CursorResponse;
+import com.example.trace.gpt.dto.VerificationDto;
+import com.example.trace.gpt.service.PostVerificationService;
 import com.example.trace.mission.dto.AssignMissionRequest;
 import com.example.trace.mission.dto.DailyMissionResponse;
 import com.example.trace.mission.dto.MissionCursorRequest;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.mission.service.DailyMissionService;
 import com.example.trace.mission.util.MissionDateUtil;
+import com.example.trace.post.dto.post.PostCreateDto;
 import com.example.trace.post.dto.post.PostDto;
+import com.example.trace.post.service.PostService;
 import com.example.trace.user.User;
 import com.example.trace.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,6 +47,8 @@ public class DailyMissionController {
 
     private final DailyMissionService missionService;
     private final UserService userService;
+    private final PostVerificationService postVerificationService;
+    private final PostService postService;
 
     /**
      * 오늘 할당된 미션을 사용자에게 반환합니다.
@@ -91,16 +97,23 @@ public class DailyMissionController {
             encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)
     ))
     public ResponseEntity<PostDto> submitDailyMission(
-            @RequestPart("request") SubmitDailyMissionDto submitDto,
+            @RequestPart("request") SubmitDailyMissionDto dailyMissionDto,
             @RequestPart(value = "imageFiles", required = false) List<MultipartFile> imageFiles,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         if (imageFiles != null && !imageFiles.isEmpty()) {
             // Limit to 5 images
             int maxImages = Math.min(imageFiles.size(), 5);
-            submitDto.setImageFiles(imageFiles.subList(0, maxImages));
+            dailyMissionDto.setImageFiles(imageFiles.subList(0, maxImages));
         }
         String providerId = principalDetails.getUser().getProviderId();
-        PostDto postDto = missionService.verifySubmissionAndCreatePost(providerId, submitDto);
+        DailyMissionResponse dailyMission = missionService.getTodaysMissionByProviderId(providerId);
+        VerificationDto verificationDto =
+                postVerificationService.verifyDailyMission(dailyMissionDto, dailyMission.getContent(), providerId);
+
+        PostCreateDto postCreateDto = PostCreateDto.createForMission(dailyMissionDto, dailyMission.getContent());
+        PostDto postDto = postService.createPost(postCreateDto, providerId, verificationDto);
+        missionService.complete(providerId, postDto.getId());
+
         return ResponseEntity.ok(postDto);
     }
 

--- a/src/main/java/com/example/trace/mission/controller/DailyMissionController.java
+++ b/src/main/java/com/example/trace/mission/controller/DailyMissionController.java
@@ -2,7 +2,6 @@ package com.example.trace.mission.controller;
 
 import com.example.trace.auth.dto.PrincipalDetails;
 import com.example.trace.global.response.CursorResponse;
-import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.gpt.service.PostVerificationService;
 import com.example.trace.mission.dto.AssignMissionRequest;
 import com.example.trace.mission.dto.DailyMissionResponse;
@@ -10,7 +9,6 @@ import com.example.trace.mission.dto.MissionCursorRequest;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.mission.service.DailyMissionService;
 import com.example.trace.mission.util.MissionDateUtil;
-import com.example.trace.post.dto.post.PostCreateDto;
 import com.example.trace.post.dto.post.PostDto;
 import com.example.trace.post.service.PostService;
 import com.example.trace.user.User;
@@ -106,13 +104,7 @@ public class DailyMissionController {
             dailyMissionDto.setImageFiles(imageFiles.subList(0, maxImages));
         }
         String providerId = principalDetails.getUser().getProviderId();
-        DailyMissionResponse dailyMission = missionService.getTodaysMissionByProviderId(providerId);
-        VerificationDto verificationDto =
-                postVerificationService.verifyDailyMission(dailyMissionDto, dailyMission.getContent(), providerId);
-
-        PostCreateDto postCreateDto = PostCreateDto.createForMission(dailyMissionDto, dailyMission.getContent());
-        PostDto postDto = postService.createPost(postCreateDto, providerId, verificationDto);
-        missionService.complete(providerId, postDto.getId());
+        PostDto postDto = missionService.handleSubmittedMission(dailyMissionDto, providerId);
 
         return ResponseEntity.ok(postDto);
     }

--- a/src/main/java/com/example/trace/mission/service/DailyMissionService.java
+++ b/src/main/java/com/example/trace/mission/service/DailyMissionService.java
@@ -58,6 +58,7 @@ public class DailyMissionService {
 
         PostCreateDto postCreateDto = PostCreateDto.createForMission(dailyMissionDto, description);
         PostDto postDto = postService.createPost(postCreateDto, userProviderId, verificationDto);
+
         complete(dailyMission, postDto.getId());
         return postDto;
     }

--- a/src/main/java/com/example/trace/post/domain/PostType.java
+++ b/src/main/java/com/example/trace/post/domain/PostType.java
@@ -1,15 +1,34 @@
 package com.example.trace.post.domain;
 
+import com.example.trace.gpt.dto.VerificationDto;
+import lombok.Getter;
+
+@Getter
 public enum PostType {
-    FREE("자유"),
-    GOOD_DEED("선행"),
-    MISSION("미션");
+    FREE("자유", 0, 0),
+    GOOD_DEED("선행", 50, 50),
+    MISSION("미션", 150, 150);
 
     private final String type;
-    PostType(String type){
+    private final Integer textScore;
+    private final Integer imageScore;
+
+    PostType(String type, Integer textScore, Integer imageScore) {
         this.type = type;
+        this.textScore = textScore;
+        this.imageScore = imageScore;
     }
-    public String getType() {
-        return type;
+
+    public Integer getTotalScore(VerificationDto verificationDto) {
+        int score = 0;
+
+        if (verificationDto.isTextResult()) {
+            score += getTextScore();
+        }
+        if (verificationDto.isImageResult()) {
+            score += getImageScore();
+        }
+
+        return score;
     }
 }

--- a/src/main/java/com/example/trace/post/dto/post/PostCreateDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostCreateDto.java
@@ -1,17 +1,17 @@
 package com.example.trace.post.dto.post;
 
+import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.post.domain.PostType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Data
 @Builder
@@ -23,7 +23,7 @@ public class PostCreateDto {
     @NotNull(message = "게시글 유형을 선택해주세요")
     @Schema(description = "게시글 유형", example = "FREE,GOOD_DEED,MISSION")
     private PostType postType;
-    
+
     @NotBlank(message = "제목을 입력해주세요")
     @Schema(description = "게시글 제목", example = "게시글 제목")
     private String title;
@@ -31,7 +31,7 @@ public class PostCreateDto {
     @Schema(description = "게시글 내용", example = "게시글 내용")
     private String content;
 
-    @Schema(description = "할당된 미션 내용", example ="종업원에게 인사하기", hidden = true)
+    @Schema(description = "할당된 미션 내용", example = "종업원에게 인사하기", hidden = true)
     private String missionContent;
 
     @JsonIgnore
@@ -39,4 +39,14 @@ public class PostCreateDto {
 
     @JsonIgnore
     private List<MultipartFile> imageFiles;
+
+    public static PostCreateDto createForMission(SubmitDailyMissionDto dailyMissionDto, String content) {
+        return PostCreateDto.builder()
+                .postType(PostType.MISSION)
+                .title(dailyMissionDto.getTitle())
+                .content(dailyMissionDto.getContent())
+                .imageFiles(dailyMissionDto.getImageFiles())
+                .missionContent(content)
+                .build();
+    }
 } 

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -76,7 +76,7 @@ public class PostServiceImpl implements PostService {
         PostType postType = postCreateDto.getPostType();
 
         if (verificationDto != null) {
-            user.updateVerification(postType);
+            user.updateVerification(verificationDto, postType);
         }
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -76,7 +76,7 @@ public class PostServiceImpl implements PostService {
         PostType postType = postCreateDto.getPostType();
 
         if (verificationDto != null) {
-            user.updateVerification(verificationDto, postType);
+            user.updateVerification(postType);
         }
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -88,7 +88,7 @@ public class PostServiceImpl implements PostService {
 
         Verification verification = null;
         if (verificationDto != null) {
-            verification = postVerificationService.makeVerification(verificationDto);
+            verification = verificationDto.toEntity();
         }
 
         Post post = Post.builder()

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -73,9 +73,10 @@ public class PostServiceImpl implements PostService {
     public PostDto createPost(PostCreateDto postCreateDto, String ProviderId, VerificationDto verificationDto) {
         User user = userRepository.findByProviderId(ProviderId)
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
+        PostType postType = postCreateDto.getPostType();
 
         if (verificationDto != null) {
-            user.updateVerification(verificationDto);
+            user.updateVerification(verificationDto, postType);
         }
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -1,6 +1,5 @@
 package com.example.trace.user;
 
-import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.notification.domain.NotificationEvent;
 import com.example.trace.post.domain.PostType;
 import jakarta.persistence.Column;
@@ -69,10 +68,11 @@ public class User {
         this.profileImageUrl = newProfileImageUrl;
     }
 
-    public void updateVerification(VerificationDto verificationDto, PostType type) {
-        if (verificationDto.isTextResult() || verificationDto.isImageResult()) {
-            verificationCount++;
-        }
+    public void tryVerification() {
+        verificationCount++;
+    }
+
+    public void updateVerification(PostType type) {
         increaseScoreBy(type);
     }
 

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -1,5 +1,6 @@
 package com.example.trace.user;
 
+import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.notification.domain.NotificationEvent;
 import com.example.trace.post.domain.PostType;
 import jakarta.persistence.Column;
@@ -72,18 +73,11 @@ public class User {
         verificationCount++;
     }
 
-    public void updateVerification(PostType type) {
-        increaseScoreBy(type);
+    public void updateVerification(VerificationDto verificationDto, PostType type) {
+        this.verificationScore += type.getTotalScore(verificationDto);
     }
 
     public boolean addNotification(NotificationEvent notificationEvent) {
         return this.notificationEvents.add(notificationEvent);
-    }
-
-    private void increaseScoreBy(PostType type) {
-        switch (type) {
-            case MISSION -> verificationScore += 150;
-            case GOOD_DEED -> verificationScore += 50;
-        }
     }
 }

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -2,6 +2,7 @@ package com.example.trace.user;
 
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.notification.domain.NotificationEvent;
+import com.example.trace.post.domain.PostType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -68,19 +69,19 @@ public class User {
         this.profileImageUrl = newProfileImageUrl;
     }
 
-    public void updateVerification(VerificationDto verificationDto) {
+    public void updateVerification(VerificationDto verificationDto, PostType type) {
         if (verificationDto.isTextResult() || verificationDto.isImageResult()) {
             verificationCount++;
         }
-        increaseScore(verificationDto);
+        increaseScoreBy(type);
     }
 
     public boolean addNotification(NotificationEvent notificationEvent) {
         return this.notificationEvents.add(notificationEvent);
     }
 
-    private void increaseScore(VerificationDto dto) {
-        switch (dto.getPostType()) {
+    private void increaseScoreBy(PostType type) {
+        switch (type) {
             case MISSION -> verificationScore += 150;
             case GOOD_DEED -> verificationScore += 50;
         }

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -72,15 +72,17 @@ public class User {
         if (verificationDto.isTextResult() || verificationDto.isImageResult()) {
             verificationCount++;
         }
-        if (verificationDto.isImageResult()) {
-            this.verificationScore += 10;
-        }
-        if (verificationDto.isTextResult()) {
-            this.verificationScore += 5;
-        }
+        increaseScore(verificationDto);
     }
 
     public boolean addNotification(NotificationEvent notificationEvent) {
         return this.notificationEvents.add(notificationEvent);
+    }
+
+    private void increaseScore(VerificationDto dto) {
+        switch (dto.getPostType()) {
+            case MISSION -> verificationScore += 150;
+            case GOOD_DEED -> verificationScore += 50;
+        }
     }
 }

--- a/src/test/java/com/example/trace/user/UserTest.java
+++ b/src/test/java/com/example/trace/user/UserTest.java
@@ -14,11 +14,10 @@ class UserTest {
     void textMissionValidation() throws Exception {
         //given
         User user = User.builder().build();
-        VerificationDto missionVerification = VerificationDto.builder()
-                .postType(PostType.MISSION).textResult(true).imageResult(false).build();
+        VerificationDto missionVerification = VerificationDto.builder().textResult(true).imageResult(false).build();
 
         //when
-        user.updateVerification(missionVerification);
+        user.updateVerification(missionVerification, PostType.MISSION);
         System.out.println(user);
         //then
         assertEquals(1L, user.getVerificationCount());
@@ -30,11 +29,10 @@ class UserTest {
     void imageMissionValidation() throws Exception {
         //given
         User user = User.builder().build();
-        VerificationDto missionVerification = VerificationDto.builder()
-                .postType(PostType.MISSION).textResult(true).imageResult(true).build();
+        VerificationDto missionVerification = VerificationDto.builder().textResult(true).imageResult(true).build();
 
         //when
-        user.updateVerification(missionVerification);
+        user.updateVerification(missionVerification, PostType.MISSION);
         System.out.println(user);
         //then
         assertEquals(1L, user.getVerificationCount());
@@ -46,11 +44,10 @@ class UserTest {
     void textPostValidation() throws Exception {
         //given
         User user = User.builder().build();
-        VerificationDto imageVerification = VerificationDto.builder()
-                .postType(PostType.GOOD_DEED).textResult(true).imageResult(false).build();
+        VerificationDto imageVerification = VerificationDto.builder().textResult(true).imageResult(false).build();
 
         //when
-        user.updateVerification(imageVerification);
+        user.updateVerification(imageVerification, PostType.GOOD_DEED);
         System.out.println(user);
         //then
         assertEquals(1L, user.getVerificationCount());
@@ -63,11 +60,10 @@ class UserTest {
     void imagePostValidation() throws Exception {
         //given
         User user = User.builder().build();
-        VerificationDto imageVerification = VerificationDto.builder()
-                .postType(PostType.GOOD_DEED).textResult(true).imageResult(true).build();
+        VerificationDto imageVerification = VerificationDto.builder().textResult(true).imageResult(true).build();
 
         //when
-        user.updateVerification(imageVerification);
+        user.updateVerification(imageVerification, PostType.GOOD_DEED);
         System.out.println(user);
         //then
         assertEquals(1L, user.getVerificationCount());

--- a/src/test/java/com/example/trace/user/UserTest.java
+++ b/src/test/java/com/example/trace/user/UserTest.java
@@ -2,7 +2,6 @@ package com.example.trace.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.post.domain.PostType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,28 +13,11 @@ class UserTest {
     void textMissionValidation() throws Exception {
         //given
         User user = User.builder().build();
-        VerificationDto missionVerification = VerificationDto.builder().textResult(true).imageResult(false).build();
 
         //when
-        user.updateVerification(missionVerification, PostType.MISSION);
-        System.out.println(user);
-        //then
-        assertEquals(1L, user.getVerificationCount());
-        assertEquals(150L, user.getVerificationScore());
-    }
+        user.updateVerification(PostType.MISSION);
 
-    @DisplayName("미션 인증 시 확득 포인트")
-    @Test
-    void imageMissionValidation() throws Exception {
-        //given
-        User user = User.builder().build();
-        VerificationDto missionVerification = VerificationDto.builder().textResult(true).imageResult(true).build();
-
-        //when
-        user.updateVerification(missionVerification, PostType.MISSION);
-        System.out.println(user);
         //then
-        assertEquals(1L, user.getVerificationCount());
         assertEquals(150L, user.getVerificationScore());
     }
 
@@ -44,31 +26,11 @@ class UserTest {
     void textPostValidation() throws Exception {
         //given
         User user = User.builder().build();
-        VerificationDto imageVerification = VerificationDto.builder().textResult(true).imageResult(false).build();
 
         //when
-        user.updateVerification(imageVerification, PostType.GOOD_DEED);
-        System.out.println(user);
+        user.updateVerification(PostType.GOOD_DEED);
+
         //then
-        assertEquals(1L, user.getVerificationCount());
         assertEquals(50L, user.getVerificationScore());
     }
-
-
-    @DisplayName("이미지를 포함한 선행 인증 시 획득 포인트")
-    @Test
-    void imagePostValidation() throws Exception {
-        //given
-        User user = User.builder().build();
-        VerificationDto imageVerification = VerificationDto.builder().textResult(true).imageResult(true).build();
-
-        //when
-        user.updateVerification(imageVerification, PostType.GOOD_DEED);
-        System.out.println(user);
-        //then
-        assertEquals(1L, user.getVerificationCount());
-        assertEquals(50L, user.getVerificationScore());
-    }
-
-
 }

--- a/src/test/java/com/example/trace/user/UserTest.java
+++ b/src/test/java/com/example/trace/user/UserTest.java
@@ -1,0 +1,78 @@
+package com.example.trace.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.example.trace.gpt.dto.VerificationDto;
+import com.example.trace.post.domain.PostType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    @DisplayName("미션 인증 시 확득 포인트")
+    @Test
+    void textMissionValidation() throws Exception {
+        //given
+        User user = User.builder().build();
+        VerificationDto missionVerification = VerificationDto.builder()
+                .postType(PostType.MISSION).textResult(true).imageResult(false).build();
+
+        //when
+        user.updateVerification(missionVerification);
+        System.out.println(user);
+        //then
+        assertEquals(1L, user.getVerificationCount());
+        assertEquals(150L, user.getVerificationScore());
+    }
+
+    @DisplayName("미션 인증 시 확득 포인트")
+    @Test
+    void imageMissionValidation() throws Exception {
+        //given
+        User user = User.builder().build();
+        VerificationDto missionVerification = VerificationDto.builder()
+                .postType(PostType.MISSION).textResult(true).imageResult(true).build();
+
+        //when
+        user.updateVerification(missionVerification);
+        System.out.println(user);
+        //then
+        assertEquals(1L, user.getVerificationCount());
+        assertEquals(150L, user.getVerificationScore());
+    }
+
+    @DisplayName("이미지를 포함한 선행 인증 시 획득 포인트")
+    @Test
+    void textPostValidation() throws Exception {
+        //given
+        User user = User.builder().build();
+        VerificationDto imageVerification = VerificationDto.builder()
+                .postType(PostType.GOOD_DEED).textResult(true).imageResult(false).build();
+
+        //when
+        user.updateVerification(imageVerification);
+        System.out.println(user);
+        //then
+        assertEquals(1L, user.getVerificationCount());
+        assertEquals(50L, user.getVerificationScore());
+    }
+
+
+    @DisplayName("이미지를 포함한 선행 인증 시 획득 포인트")
+    @Test
+    void imagePostValidation() throws Exception {
+        //given
+        User user = User.builder().build();
+        VerificationDto imageVerification = VerificationDto.builder()
+                .postType(PostType.GOOD_DEED).textResult(true).imageResult(true).build();
+
+        //when
+        user.updateVerification(imageVerification);
+        System.out.println(user);
+        //then
+        assertEquals(1L, user.getVerificationCount());
+        assertEquals(50L, user.getVerificationScore());
+    }
+
+
+}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
선행 인증 시 획득하는 포인트의 양을 변경하였습니다. 

## 2. ✨새롭게 변경된 점
- 포인트 크기
- verficationCount 사용 안함
- DailyMissionController 의 인증 메서드 호출 흐름 변경

기존 코드에서 `MissionService.verifySubmissionAndCreatePost()`가 너무 많은 역할을 가져서 이를 분리했습니다. 

그리고 user의 인증 시도 횟수(`verificationCount`)가 증가하는 시점과 선행 점수(`verficationScore`)가 증가하는 시점이 달라야 했는데, 예외를 던지는 하나의 메서드에서 두 상태를 변경하고 있었고 그래서 변경된 상태가 `Rollback`되었습니다. (처음엔 이걸 해결하기 위해서 메서드 분리를 시작했습니다.)

변경된 상태가 `GptException`으로 인해 롤백되는걸 방지하기 위해 `noRollbackFor`도 붙여봤지만 `createPost`메서드가 선행 인증 게시글에선 `controller`단에서 호출되고, 미션 인증 시엔 `service`의 메서드 내에서 호출되어 이를 해결할 수 없었습니다.

그래서 메서드 분리를 결심했고, 꽤나 만족스러운 결과를 얻은 것 같습니다 :)

## 3. 🔖 기타 사항
redis를 설치하고, 로컬 테스트를 돌리기 위해 h2까지 처음 다뤄봐서 간단한 결과지만 과정이 꽤 오래 걸렸네요. 덕분에 로직을 꽤 많이 이해했습니다 :)

## 4. 📸 스크린샷(선택)
<img width="222" height="153" alt="image" src="https://github.com/user-attachments/assets/289a41c4-d98d-4ba5-9cde-76a5ea300e17" />


## 5. 💡알게된 혹은 궁금한 사항들
원치 않게 많은 코드를 수정한 건 죄송합니다.. 우려되는 부분이 있다면 편하게 말씀주세요~