### PR TITLE
createdAt 필드를 DATETIME(6)로 저장하도록 변경

### DIFF
--- a/src/main/java/com/example/trace/notification/domain/NotificationEvent.java
+++ b/src/main/java/com/example/trace/notification/domain/NotificationEvent.java
@@ -60,6 +60,7 @@ public class NotificationEvent implements Comparable<NotificationEvent> {
     @Convert(converter = NotificationDataConverter.class)
     private NotificationData data;
 
+    @Column(name = "created_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime createdAt;
 
     @Builder.Default


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- H2에선 LocalDateTime을 TIMESTAMP or DATETIME으로 자동 매핑됨
- MySQL에선 이를 지원하지 않아 직접 명시해야 됨

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
