### PR TITLE
프로메테우스 jwt 필터 로그 없애기

### DIFF
--- a/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
@@ -1,27 +1,26 @@
 package com.example.trace.auth;
 
 
+import com.example.trace.auth.Util.JwtUtil;
+import com.example.trace.auth.Util.RedisUtil;
+import com.example.trace.auth.dto.PrincipalDetails;
+import com.example.trace.auth.repository.UserRepository;
 import com.example.trace.global.errorcode.TokenErrorCode;
 import com.example.trace.global.exception.TokenException;
 import com.example.trace.user.User;
-import com.example.trace.auth.dto.PrincipalDetails;
-import com.example.trace.auth.Util.JwtUtil;
-import com.example.trace.auth.Util.RedisUtil;
-import com.example.trace.auth.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.util.AntPathMatcher;
-
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
@@ -44,6 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/v1/api/user/*",
             "/idtoken",
             "/token/refresh",
+            "/actuator/**",
             // Swagger UI v3 (OpenAPI)
             "/v3/api-docs/**",
             "/api-docs/**",
@@ -57,7 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        
+
         //
         return excludePathPatterns.stream()
                 .anyMatch(pattern -> pathMatcher.match(pattern, path));
@@ -69,7 +69,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        try{
+        try {
             log.info("[*] Jwt Filter - Request URI: {}", request.getRequestURI());
             String accessToken = jwtUtil.resolveAccessToken(request);
 
@@ -88,7 +88,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 throw new TokenException(TokenErrorCode.LOGOUT_TOKEN);
             }
 
-            if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("delete")){
+            if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("delete")) {
                 log.info("[*] Deleted account accessToken");
                 throw new TokenException(TokenErrorCode.DELETED_USER);
             }
@@ -99,7 +99,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // accessToken에서 providerId 추출
             String providerId = jwtUtil.getProviderId(accessToken);
             // accessToken에서 providerId로 User 객체를 가져옴
-            User user = userRepository.findByProviderIdAndProvider(providerId,"KAKAO").orElseThrow(() -> new UsernameNotFoundException("User not found"));
+            User user = userRepository.findByProviderIdAndProvider(providerId, "KAKAO").orElseThrow(() -> new UsernameNotFoundException("User not found"));
             // accesstoken을 기반으로 principalDetail 저장
             PrincipalDetails principalDetails = new PrincipalDetails(user);
 
@@ -115,11 +115,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
 
-        }catch (TokenException e){
+        } catch (TokenException e) {
             log.error("[*] Jwt Filter - TokenException: {}", e.getMessage());
             handlerExceptionResolver.resolveException(request, response, null, e);
 
-        } catch (Exception e){
+        } catch (Exception e) {
             log.error("[*] Jwt Filter - Exception: {}", e.getMessage());
         }
 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

```
Aug  5 14:46:55 ip-172-31-7-113 web[198347]: 2025-08-05T14:46:55.106+09:00  INFO 198347 --- [Trace] [io-5000-exec-10] c.e.trace.auth.JwtAuthenticationFilter   : [*] Jwt Filter - Request URI: /api/v1/actuator/prometheus
Aug  5 14:46:55 ip-172-31-7-113 web[198347]: 2025-08-05T14:46:55.108+09:00  WARN 198347 --- [Trace] [io-5000-exec-10] com.example.trace.auth.Util.JwtUtil      : [*] No Token in req
Aug  5 14:46:55 ip-172-31-7-113 web[198347]: 2025-08-05T14:46:55.108+09:00  INFO 198347 --- [Trace] [io-5000-exec-10] c.e.trace.auth.JwtAuthenticationFilter   : [*] No accessToken, proceeding to next filter for URI: /api/v1/actuator/prometheus
```
현재 /api/v1/actuator/prometheus에 대한 엔드포인트로 접근할 때, jwt 인증 필터를 거치고 있기 때문에
불필요한 로그가 계속 발생하여 다른 로그를 보기 어려운 상황이다. 

jwt 인증 필터 제외 목록에 "/actuator/**" 를 추가시켜야 한다.

## 2. ✨새롭게 변경된 점

프로메테우스에 대한 경로 패턴을 jwt 필터에서 제외

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
