### PR TITLE
잘못된 인자 전달로 실패하는 테스트 수정

### DIFF
--- a/src/test/java/com/example/trace/user/UserTest.java
+++ b/src/test/java/com/example/trace/user/UserTest.java
@@ -2,6 +2,7 @@ package com.example.trace.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.post.domain.PostType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,12 +14,33 @@ class UserTest {
     void textMissionValidation() throws Exception {
         //given
         User user = User.builder().build();
+        VerificationDto verificationDto = VerificationDto.builder()
+                .imageResult(false)
+                .textResult(true)
+                .build();
 
         //when
-        user.updateVerification(PostType.MISSION);
+        user.updateVerification(verificationDto, PostType.MISSION);
 
         //then
         assertEquals(150L, user.getVerificationScore());
+    }
+
+    @DisplayName("미션 인증 시 확득 포인트")
+    @Test
+    void imageMissionValidation() throws Exception {
+        //given
+        User user = User.builder().build();
+        VerificationDto verificationDto = VerificationDto.builder()
+                .imageResult(true)
+                .textResult(true)
+                .build();
+
+        //when
+        user.updateVerification(verificationDto, PostType.MISSION);
+
+        //then
+        assertEquals(300L, user.getVerificationScore());
     }
 
     @DisplayName("이미지를 포함한 선행 인증 시 획득 포인트")
@@ -26,11 +48,32 @@ class UserTest {
     void textPostValidation() throws Exception {
         //given
         User user = User.builder().build();
+        VerificationDto verificationDto = VerificationDto.builder()
+                .imageResult(false)
+                .textResult(true)
+                .build();
 
         //when
-        user.updateVerification(PostType.GOOD_DEED);
+        user.updateVerification(verificationDto, PostType.GOOD_DEED);
 
         //then
         assertEquals(50L, user.getVerificationScore());
+    }
+
+    @DisplayName("이미지를 포함한 선행 인증 시 획득 포인트")
+    @Test
+    void imagePostValidation() throws Exception {
+        //given
+        User user = User.builder().build();
+        VerificationDto verificationDto = VerificationDto.builder()
+                .imageResult(true)
+                .textResult(true)
+                .build();
+
+        //when
+        user.updateVerification(verificationDto, PostType.GOOD_DEED);
+
+        //then
+        assertEquals(100L, user.getVerificationScore());
     }
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
이전 PR에서 메서드 형태를 변경했는데 테스트에 반영하지 않아 테스트가 실패하고, cicd에 실패하였음.

이를 해결하기 위해 올바른 파라미터를 전달함.

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
