### PR TITLE
인증 게시글 및 미션 완료 수 조회 API

### DIFF
--- a/src/main/java/com/example/trace/bird/Bird.java
+++ b/src/main/java/com/example/trace/bird/Bird.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Bird {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/trace/bird/BirdLevel.java
+++ b/src/main/java/com/example/trace/bird/BirdLevel.java
@@ -17,13 +17,13 @@ public enum BirdLevel {
 
     private final int level;
     private final String name;
-    private final int requiredGoodDeedCount;
+    private final int requiredVerifiedPostCount;
     private final int requiredMissionCount;
 
-    BirdLevel(int level, String name, int requiredGoodDeedCount, int requiredMissionCount) {
+    BirdLevel(int level, String name, int requiredVerifiedPostCount, int requiredMissionCount) {
         this.level = level;
         this.name = name;
-        this.requiredGoodDeedCount = requiredGoodDeedCount;
+        this.requiredVerifiedPostCount = requiredVerifiedPostCount;
         this.requiredMissionCount = requiredMissionCount;
     }
 

--- a/src/main/java/com/example/trace/bird/BirdService.java
+++ b/src/main/java/com/example/trace/bird/BirdService.java
@@ -43,7 +43,7 @@ public class BirdService {
     }
 
     public Optional<BirdLevel> findUnlockableBird(User user) {
-        long verificationCount = user.getVerificationCount();
+        long verifiedPostCount = user.getVerifiedPostCount();
         long completedMissionCount = user.getCompletedMissionCount();
 
         BirdLevel highestOwnedBirdLevel = getHighestOwnedBirdLevel(user);
@@ -54,7 +54,7 @@ public class BirdService {
 
         BirdLevel nextBirdLevel = BirdLevel.fromLevel(highestOwnedBirdLevel.getLevel() + 1);
 
-        if (verificationCount >= nextBirdLevel.getRequiredGoodDeedCount() &&
+        if (verifiedPostCount >= nextBirdLevel.getRequiredVerifiedPostCount() &&
                 completedMissionCount >= nextBirdLevel.getRequiredMissionCount()) {
             return Optional.of(nextBirdLevel);
         }

--- a/src/main/java/com/example/trace/bird/BirdService.java
+++ b/src/main/java/com/example/trace/bird/BirdService.java
@@ -76,11 +76,12 @@ public class BirdService {
         birdRepository.save(newBird);
     }
 
-    public void checkAndUnlockBirdLevel(User user) {
+    public Optional<BirdLevel> checkAndUnlockBirdLevel(User user) {
         Optional<BirdLevel> unlockableBirdLevel = findUnlockableBird(user);
         if (unlockableBirdLevel.isPresent()) {
             unlockBird(user, unlockableBirdLevel.get());
         }
+        return unlockableBirdLevel;
     }
 
 }

--- a/src/main/java/com/example/trace/global/fcm/FcmTokenNotificationService.java
+++ b/src/main/java/com/example/trace/global/fcm/FcmTokenNotificationService.java
@@ -1,23 +1,16 @@
 package com.example.trace.global.fcm;
 
-import static com.example.trace.global.errorcode.TokenErrorCode.NOT_FOUND_FCM_TOKEN;
-
-import com.example.trace.global.exception.TokenException;
 import com.example.trace.notification.domain.NotificationEvent.NotificationData;
-import com.google.firebase.messaging.BatchResponse;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.MessagingErrorCode;
-import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +28,6 @@ public class FcmTokenNotificationService {
 
         if (tokenOpt.isEmpty()) {
             log.warn("FCM 토큰을 찾을 수 없습니다 - 사용자 ID: {}", providerId);
-            throw new TokenException(NOT_FOUND_FCM_TOKEN);
         }
 
         String token = tokenOpt.get();

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -13,15 +13,6 @@ import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.completion.chat.ChatMessageRole;
 import com.theokanning.openai.service.OpenAiService;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +23,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -89,7 +86,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
 
         VerificationDto result = verifyMissionTextAndImages(requestContent, missionContent, images);
 
-        if (!result.isTextResult() || !result.isImageResult()) {
+        if (!result.isTextResult() && !result.isImageResult()) {
             String failureReason = result.getFailureReason();
             log.info("실패 이유 : {}", failureReason);
             throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
@@ -125,7 +122,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
             // Both text and image verification is needed
             VerificationDto result = verifyTextAndImages(content, images);
 
-            if (!result.isTextResult() || !result.isImageResult()) {
+            if (!result.isTextResult() && !result.isImageResult()) {
                 String failureReason = result.getFailureReason();
                 throw new GptException(GptErrorCode.WRONG_CONTENT, failureReason);
             }

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -4,27 +4,7 @@ import com.example.trace.global.errorcode.PostErrorCode;
 import com.example.trace.global.exception.PostException;
 import com.example.trace.gpt.domain.Verification;
 import com.example.trace.user.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -33,10 +13,16 @@ import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "posts")
 @Data
 @NoArgsConstructor
+// TODO(seobeeeee): 연관관계 정리
 public class Post {
 
     @Id

--- a/src/main/java/com/example/trace/post/dto/post/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostDto.java
@@ -1,5 +1,6 @@
 package com.example.trace.post.dto.post;
 
+import com.example.trace.bird.BirdLevel;
 import com.example.trace.emotion.EmotionType;
 import com.example.trace.emotion.dto.EmotionCountDto;
 import com.example.trace.post.domain.Post;
@@ -72,14 +73,21 @@ public class PostDto {
 
     @Schema(description = "미션 게시글일 때 보낼 content", example = "부모님 심부름에 다녀왔습니다.")
     private String missionContent;
-    
+
+    @Schema(description = "레벨업 여부", example = "false")
+    private boolean isLevelUp;
+
+    @Schema(description = "새로운 레벨", example = "BABY_BIRD")
+    private BirdLevel birdLevel;
+
+
     public static PostDto fromEntity(Post post) {
-        List<String> imageUrls = post.getImages() != null ? 
+        List<String> imageUrls = post.getImages() != null ?
                 post.getImages().stream()
-                .map(PostImage::getImageUrl)
-                .collect(Collectors.toList()) : 
+                        .map(PostImage::getImageUrl)
+                        .collect(Collectors.toList()) :
                 new ArrayList<>();
-                
+
         return PostDto.builder()
                 .id(post.getId())
                 .postType(post.getPostType())
@@ -109,10 +117,12 @@ public class PostDto {
                 .missionContent(post.getPostType() == PostType.MISSION ? post.getMissionContent() : null)
                 .build();
     }
-    
 
-    
+    public PostDto addLevelUpInfo(BirdLevel birdLevel, boolean isLevelUp) {
+        this.birdLevel = birdLevel;
+        this.isLevelUp = isLevelUp;
+        return this;
+    }
 
-    
 
 } 

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.trace.post.service;
 
 import com.example.trace.auth.repository.UserRepository;
+import com.example.trace.bird.BirdLevel;
 import com.example.trace.bird.BirdService;
 import com.example.trace.emotion.EmotionService;
 import com.example.trace.emotion.EmotionType;
@@ -60,9 +61,17 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
         PostType postType = postCreateDto.getPostType();
 
+        boolean isLevelUp = false;
+        BirdLevel birdLevel = null;
+
+        Verification verification = null;
         if (verificationDto != null) {
+            verification = verificationDto.toEntity();
             user.updateVerification(verificationDto, postType);
-            birdService.checkAndUnlockBirdLevel(user);
+            birdLevel = birdService.checkAndUnlockBirdLevel(user).orElse(null);
+            if (birdLevel != null) {
+                isLevelUp = true;
+            }
         }
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {
@@ -73,10 +82,6 @@ public class PostServiceImpl implements PostService {
             throw new PostException(PostErrorCode.TITLE_EMPTY);
         }
 
-        Verification verification = null;
-        if (verificationDto != null) {
-            verification = verificationDto.toEntity();
-        }
 
         Post post = Post.builder()
                 .postType(postCreateDto.getPostType())
@@ -95,6 +100,7 @@ public class PostServiceImpl implements PostService {
 
         Post savedPost = postRepository.save(post);
 
+        // TODO(seobeeeee1001): 이미지 업로드 로직 분리
         List<MultipartFile> imageFiles = postCreateDto.getImageFiles();
         if (imageFiles != null && !imageFiles.isEmpty()) {
             int imagesToProcess = Math.min(imageFiles.size(), MAX_IMAGES);
@@ -116,7 +122,10 @@ public class PostServiceImpl implements PostService {
             }
         }
 
-        return PostDto.fromEntity(savedPost);
+        PostDto postDto = PostDto.fromEntity(savedPost);
+        postDto.addLevelUpInfo(birdLevel, isLevelUp);
+
+        return postDto;
     }
 
     @Override

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -63,7 +63,6 @@ public class PostServiceImpl implements PostService {
         if (verificationDto != null) {
             user.updateVerification(verificationDto, postType);
             birdService.checkAndUnlockBirdLevel(user);
-            user.updateVerification(verificationDto, postType);
         }
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -2,21 +2,8 @@ package com.example.trace.user;
 
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.notification.domain.NotificationEvent;
-
-import jakarta.persistence.*;
 import com.example.trace.post.domain.PostType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
-
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,7 +39,7 @@ public class User {
     private Long verificationScore = 0L;
 
     @Builder.Default
-    private Long verificationCount = 0L;
+    private Long verifiedPostCount = 0L;
 
     @Builder.Default
     private Long completedMissionCount = 0L;
@@ -78,16 +65,15 @@ public class User {
         this.profileImageUrl = newProfileImageUrl;
     }
 
-    public void tryVerification() {
-        verificationCount++;
-    }
-
     public void updateVerification(VerificationDto verificationDto, PostType type) {
         this.verificationScore += type.getTotalScore(verificationDto);
-    }
-
-    public void updateCompletedMissionCount() {
-        this.completedMissionCount++;
+        if (verificationDto.isTextResult() || verificationDto.isImageResult()) {
+            if (type == PostType.GOOD_DEED) {
+                this.verifiedPostCount++;
+            } else if (type == PostType.MISSION) {
+                this.completedMissionCount++;
+            }
+        }
     }
 
     public boolean addNotification(NotificationEvent notificationEvent) {

--- a/src/main/java/com/example/trace/user/UserController.java
+++ b/src/main/java/com/example/trace/user/UserController.java
@@ -12,6 +12,7 @@ import com.example.trace.report.service.UserBlockService;
 import com.example.trace.user.dto.BlockedUserProfileDto;
 import com.example.trace.user.dto.UpdateNickNameRequest;
 import com.example.trace.user.dto.UserDto;
+import com.example.trace.user.dto.UserVerificationInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -151,5 +152,13 @@ public class UserController {
         String providerId = principalDetails.getUser().getProviderId();
         CursorResponse<PostFeedDto> response = postService.getMyPagePostsWithCursor(request, providerId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/verifications")
+    @Operation(summary = "사용자의 인증 개수 정보 조회", description = "사용자의 인증 개수 정보를 조회합니다.")
+    public ResponseEntity<UserVerificationInfo> getUserVerificationInfo(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        return ResponseEntity.ok(userService.getUserVerificationInfo(user));
     }
 }

--- a/src/main/java/com/example/trace/user/UserService.java
+++ b/src/main/java/com/example/trace/user/UserService.java
@@ -13,6 +13,7 @@ import com.example.trace.report.repository.UserBlockRepository;
 import com.example.trace.user.dto.BlockedUserProfileDto;
 import com.example.trace.user.dto.UpdateNickNameRequest;
 import com.example.trace.user.dto.UserDto;
+import com.example.trace.user.dto.UserVerificationInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,5 +103,9 @@ public class UserService {
         redisUtil.save(accessToken, "delete", expiration, TimeUnit.MILLISECONDS);
         String redisKey = "RT:" + providerId;
         redisUtil.delete(redisKey);
+    }
+
+    public UserVerificationInfo getUserVerificationInfo(User user) {
+        return UserVerificationInfo.from(user);
     }
 }

--- a/src/main/java/com/example/trace/user/dto/UserDto.java
+++ b/src/main/java/com/example/trace/user/dto/UserDto.java
@@ -29,7 +29,7 @@ public class UserDto {
                 .profileImageUrl(user.getProfileImageUrl())
                 .email(user.getEmail())
                 .verificationScore(user.getVerificationScore())
-                .verificationCount(user.getVerificationCount())
+                .verificationCount(user.getVerifiedPostCount() + user.getCompletedMissionCount())
                 .build();
     }
 }

--- a/src/main/java/com/example/trace/user/dto/UserVerificationInfo.java
+++ b/src/main/java/com/example/trace/user/dto/UserVerificationInfo.java
@@ -1,0 +1,24 @@
+package com.example.trace.user.dto;
+
+import com.example.trace.user.User;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Data
+public class UserVerificationInfo {
+    private Long verifiedPostCount;
+    private Long completedMissionCount;
+
+    public UserVerificationInfo(Long verifiedPostCount, Long completedMissionCount) {
+        this.verifiedPostCount = verifiedPostCount;
+        this.completedMissionCount = completedMissionCount;
+    }
+
+    public static UserVerificationInfo from(User user) {
+        return new UserVerificationInfo(
+                user.getVerifiedPostCount(),
+                user.getCompletedMissionCount()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: dev
+    active: local-mysql
   jpa:
     properties:
       hibernate:
@@ -252,7 +252,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/tracedb?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: your-passwd
+    password: qwer1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

## 2. ✨새롭게 변경된 점

- 인증 게시글 및 미션 완료 수 조회 API 생성

- 게시글 생성 응답에 제비 성장 여부 포함

- 알림 전송에 실패해도 예외처리 던지지 않음

- 인증 실패 시 던지는 예외처리 로직 수정 ( 둘 다 실패여야 던지도록)

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
