### PR TITLE
포인트 적립 목록 구현

### DIFF
--- a/src/main/java/com/example/trace/mission/service/DailyMissionService.java
+++ b/src/main/java/com/example/trace/mission/service/DailyMissionService.java
@@ -16,7 +16,6 @@ import com.example.trace.mission.repository.MissionRepository;
 import com.example.trace.mission.util.MissionDateUtil;
 import com.example.trace.notification.service.NotificationEventService;
 import com.example.trace.point.PointService;
-import com.example.trace.point.PointSource;
 import com.example.trace.post.dto.post.PostCreateDto;
 import com.example.trace.post.dto.post.PostDto;
 import com.example.trace.post.service.PostService;
@@ -64,7 +63,7 @@ public class DailyMissionService {
         PostCreateDto postCreateDto = PostCreateDto.createForMission(dailyMissionDto, description);
         PostDto postDto = postService.createPost(postCreateDto, userProviderId, verificationDto);
 
-        complete(dailyMission, postDto.getId(), verificationDto.isTextResult(), user);
+        complete(dailyMission, postDto.getId(), user);
         return postDto;
     }
 
@@ -192,14 +191,9 @@ public class DailyMissionService {
                 .build();
     }
 
-    private void complete(DailyMission assignedDailyMission, Long postId, boolean isText, User user) {
+    private void complete(DailyMission assignedDailyMission, Long postId, User user) {
         assignedDailyMission.updateVerification(true, postId);
         dailyMissionRepository.save(assignedDailyMission);
-        if (isText) {
-            pointService.save(PointSource.MISSION_POST_TEXT, user);
-        } else {
-            pointService.save(PointSource.MISSION_POST_IMAGE, user);
-        }
     }
 }
 

--- a/src/main/java/com/example/trace/mission/service/DailyMissionService.java
+++ b/src/main/java/com/example/trace/mission/service/DailyMissionService.java
@@ -15,6 +15,8 @@ import com.example.trace.mission.repository.DailyMissionRepository;
 import com.example.trace.mission.repository.MissionRepository;
 import com.example.trace.mission.util.MissionDateUtil;
 import com.example.trace.notification.service.NotificationEventService;
+import com.example.trace.point.PointService;
+import com.example.trace.point.PointSource;
 import com.example.trace.post.dto.post.PostCreateDto;
 import com.example.trace.post.dto.post.PostDto;
 import com.example.trace.post.service.PostService;
@@ -45,6 +47,7 @@ public class DailyMissionService {
 
     private static final int MAX_CHANGES_PER_DAY = 10;
     private static final int DEFAULT_PAGE_SIZE = 20;
+    private final PointService pointService;
 
 
     @Transactional
@@ -61,7 +64,7 @@ public class DailyMissionService {
         PostCreateDto postCreateDto = PostCreateDto.createForMission(dailyMissionDto, description);
         PostDto postDto = postService.createPost(postCreateDto, userProviderId, verificationDto);
 
-        complete(dailyMission, postDto.getId());
+        complete(dailyMission, postDto.getId(), verificationDto.isTextResult(), user);
         return postDto;
     }
 
@@ -189,9 +192,14 @@ public class DailyMissionService {
                 .build();
     }
 
-    private void complete(DailyMission assignedDailyMission, Long postId) {
+    private void complete(DailyMission assignedDailyMission, Long postId, boolean isText, User user) {
         assignedDailyMission.updateVerification(true, postId);
         dailyMissionRepository.save(assignedDailyMission);
+        if (isText) {
+            pointService.save(PointSource.MISSION_POST_TEXT, user);
+        } else {
+            pointService.save(PointSource.MISSION_POST_IMAGE, user);
+        }
     }
 }
 

--- a/src/main/java/com/example/trace/point/Point.java
+++ b/src/main/java/com/example/trace/point/Point.java
@@ -10,10 +10,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Point {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +28,7 @@ public class Point {
 
     private Integer value;
 
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
@@ -29,4 +37,12 @@ public class Point {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    public static Point of(PointSource source, User user) {
+        return Point.builder()
+                .source(source)
+                .value(source.getPoints())
+                .user(user)
+                .build();
+    }
 }

--- a/src/main/java/com/example/trace/point/Point.java
+++ b/src/main/java/com/example/trace/point/Point.java
@@ -1,6 +1,7 @@
 package com.example.trace.point;
 
 import com.example.trace.user.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -9,7 +10,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,9 +29,10 @@ public class Point {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Integer value;
+    private Integer amount;
 
     @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
@@ -38,11 +42,16 @@ public class Point {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public static Point of(PointSource source, User user) {
+    public static Point of(PointSource source, int points, User user) {
         return Point.builder()
                 .source(source)
-                .value(source.getPoints())
+                .amount(points)
                 .user(user)
                 .build();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/example/trace/point/Point.java
+++ b/src/main/java/com/example/trace/point/Point.java
@@ -1,0 +1,32 @@
+package com.example.trace.point;
+
+import com.example.trace.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Point {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer value;
+
+    private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    private PointSource source;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/example/trace/point/Point.java
+++ b/src/main/java/com/example/trace/point/Point.java
@@ -1,5 +1,6 @@
 package com.example.trace.point;
 
+import com.example.trace.post.domain.Post;
 import com.example.trace.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -42,13 +44,12 @@ public class Point {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public static Point of(PointSource source, int points, User user) {
-        return Point.builder()
-                .source(source)
-                .amount(points)
-                .user(user)
-                .build();
-    }
+    @OneToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(nullable = false)
+    private String content;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/example/trace/point/PointController.java
+++ b/src/main/java/com/example/trace/point/PointController.java
@@ -1,0 +1,38 @@
+package com.example.trace.point;
+
+import com.example.trace.auth.dto.PrincipalDetails;
+import com.example.trace.global.response.CursorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/points")
+@Tag(name = "Point", description = "획득 포인트 관련 API")
+public class PointController {
+    private final PointService pointService;
+
+    @GetMapping("/list")
+    @Operation(summary = "획득한 포인트 목록 조회", description = "첫 페이지를 보려면 size만 보내고, 두 번째 이후 페이지를 보려면 id와 dateTime을 포함하여 보내주세요.")
+    public ResponseEntity<?> get(
+            @AuthenticationPrincipal PrincipalDetails userDetails,
+            @RequestParam("size") Integer size,
+            @RequestParam(value = "cursorId", required = false) Long cursorId,
+            @RequestParam(value = "cursorDateTime", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorDateTime
+    ) {
+        CursorResponse<PointResponse> pointPage = pointService.getPage(size, cursorId, cursorDateTime,
+                userDetails.getUser());
+
+        return ResponseEntity.ok(pointPage);
+    }
+}

--- a/src/main/java/com/example/trace/point/PointRepository.java
+++ b/src/main/java/com/example/trace/point/PointRepository.java
@@ -1,0 +1,29 @@
+package com.example.trace.point;
+
+import com.example.trace.user.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PointRepository extends JpaRepository<Point, Long> {
+    @Query("SELECT p FROM Point P WHERE p.user = :user ORDER BY p.createdAt DESC, p.id DESC")
+    List<Point> findFirstPage(@Param("user") User user, Pageable pageable);
+
+    @Query("""
+                            SELECT p FROM Point p
+                            WHERE p.user = :user AND (
+                            p.createdAt < :dateTime OR
+                            (p.createdAt = :dateTime AND p.id < :id)
+                            )
+                            ORDER BY p.createdAt DESC, p.id DESC
+            """)
+    List<Point> findNextPage(
+            @Param("user") User user,
+            @Param("cursorDateTime") LocalDateTime dateTime,
+            @Param("id") Long id,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/example/trace/point/PointRepository.java
+++ b/src/main/java/com/example/trace/point/PointRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
-    @Query("SELECT p FROM Point P WHERE p.user = :user ORDER BY p.createdAt DESC, p.id DESC")
+    @Query("SELECT p FROM Point p WHERE p.user = :user ORDER BY p.createdAt DESC, p.id DESC")
     List<Point> findFirstPage(@Param("user") User user, Pageable pageable);
 
     @Query("""
@@ -22,7 +22,7 @@ public interface PointRepository extends JpaRepository<Point, Long> {
             """)
     List<Point> findNextPage(
             @Param("user") User user,
-            @Param("cursorDateTime") LocalDateTime dateTime,
+            @Param("dateTime") LocalDateTime dateTime,
             @Param("id") Long id,
             Pageable pageable
     );

--- a/src/main/java/com/example/trace/point/PointResponse.java
+++ b/src/main/java/com/example/trace/point/PointResponse.java
@@ -8,14 +8,14 @@ import lombok.Getter;
 @Builder
 public class PointResponse {
     private Long id;
-    private Integer value;
+    private Integer amount;
     private LocalDateTime createdAt;
     private PointSource source;
 
     public static PointResponse fromEntity(Point point) {
         return PointResponse.builder()
                 .id(point.getId())
-                .value(point.getValue())
+                .amount(point.getAmount())
                 .createdAt(point.getCreatedAt())
                 .source(point.getSource())
                 .build();

--- a/src/main/java/com/example/trace/point/PointResponse.java
+++ b/src/main/java/com/example/trace/point/PointResponse.java
@@ -1,15 +1,21 @@
 package com.example.trace.point;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "획득 포인트 목록 응답")
 public class PointResponse {
+    @Schema(description = "포인트 id", example = "1")
     private Long id;
+    @Schema(description = "획득한 포인트 양", example = "50")
     private Integer amount;
+    @Schema(description = "포인트를 획득한 시간", example = "")
     private LocalDateTime createdAt;
+    @Schema(description = "포인트 획득 경로")
     private PointSource source;
 
     public static PointResponse fromEntity(Point point) {

--- a/src/main/java/com/example/trace/point/PointResponse.java
+++ b/src/main/java/com/example/trace/point/PointResponse.java
@@ -1,0 +1,23 @@
+package com.example.trace.point;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PointResponse {
+    private Long id;
+    private Integer value;
+    private LocalDateTime createdAt;
+    private PointSource source;
+
+    public static PointResponse fromEntity(Point point) {
+        return PointResponse.builder()
+                .id(point.getId())
+                .value(point.getValue())
+                .createdAt(point.getCreatedAt())
+                .source(point.getSource())
+                .build();
+    }
+}

--- a/src/main/java/com/example/trace/point/PointResponse.java
+++ b/src/main/java/com/example/trace/point/PointResponse.java
@@ -13,16 +13,22 @@ public class PointResponse {
     private Long id;
     @Schema(description = "획득한 포인트 양", example = "50")
     private Integer amount;
-    @Schema(description = "포인트를 획득한 시간", example = "")
+    @Schema(description = "포인트를 획득한 시간", example = "2025-08-08T11:12:58.016Z")
     private LocalDateTime createdAt;
-    @Schema(description = "포인트 획득 경로")
+    @Schema(description = "포인트 획득 경로", example = "GOOD_DEED_POST")
     private PointSource source;
+    @Schema(description = "관련 리소스 Id", example = "1")
+    private Long postId;
+    @Schema(description = "관련 리소스 내용", example = "할머니를 도와드렸다.")
+    private String content;
 
     public static PointResponse fromEntity(Point point) {
         return PointResponse.builder()
                 .id(point.getId())
                 .amount(point.getAmount())
                 .createdAt(point.getCreatedAt())
+                .postId(point.getPost().getId())
+                .content(point.getContent())
                 .source(point.getSource())
                 .build();
     }

--- a/src/main/java/com/example/trace/point/PointService.java
+++ b/src/main/java/com/example/trace/point/PointService.java
@@ -3,8 +3,10 @@ package com.example.trace.point;
 import com.example.trace.global.response.CursorResponse;
 import com.example.trace.global.response.CursorResponse.CursorMeta;
 import com.example.trace.gpt.dto.VerificationDto;
+import com.example.trace.post.domain.Post;
 import com.example.trace.post.domain.PostType;
 import com.example.trace.user.User;
+import com.example.trace.util.StringUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +22,20 @@ public class PointService {
     private final PointRepository pointRepository;
 
     @Transactional
-    public void grantPointForPost(PostType postType, User user, VerificationDto verification) {
-        PointSource source = postType == PostType.MISSION ? PointSource.MISSION_POST : PointSource.GOOD_DEED_POST;
+    public void grantPointForPost(Post post, User user, VerificationDto verification) {
+        PointSource source =
+                post.getPostType() == PostType.MISSION ? PointSource.MISSION_POST : PointSource.GOOD_DEED_POST;
         int finalPoints = source.calculatePointFor(verification);
+        String previewContent = StringUtil.truncateLess(post.getContent());
 
-        Point point = Point.of(source, finalPoints, user);
+        Point point = Point.builder()
+                .source(source)
+                .amount(finalPoints)
+                .post(post)
+                .content(previewContent)
+                .user(user)
+                .build();
+
         pointRepository.save(point);
     }
 

--- a/src/main/java/com/example/trace/point/PointService.java
+++ b/src/main/java/com/example/trace/point/PointService.java
@@ -2,6 +2,8 @@ package com.example.trace.point;
 
 import com.example.trace.global.response.CursorResponse;
 import com.example.trace.global.response.CursorResponse.CursorMeta;
+import com.example.trace.gpt.dto.VerificationDto;
+import com.example.trace.post.domain.PostType;
 import com.example.trace.user.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,8 +20,11 @@ public class PointService {
     private final PointRepository pointRepository;
 
     @Transactional
-    public void save(PointSource pointSource, User user) {
-        Point point = Point.of(pointSource, user);
+    public void grantPointForPost(PostType postType, User user, VerificationDto verification) {
+        PointSource source = postType == PostType.MISSION ? PointSource.MISSION_POST : PointSource.GOOD_DEED_POST;
+        int finalPoints = source.calculatePointFor(verification);
+
+        Point point = Point.of(source, finalPoints, user);
         pointRepository.save(point);
     }
 

--- a/src/main/java/com/example/trace/point/PointService.java
+++ b/src/main/java/com/example/trace/point/PointService.java
@@ -17,6 +17,12 @@ public class PointService {
 
     private final PointRepository pointRepository;
 
+    @Transactional
+    public void save(PointSource pointSource, User user) {
+        Point point = Point.of(pointSource, user);
+        pointRepository.save(point);
+    }
+
     @Transactional(readOnly = true)
     public CursorResponse<PointResponse> getPage(Integer size, Long id, LocalDateTime dateTime, User user) {
         List<Point> points;

--- a/src/main/java/com/example/trace/point/PointService.java
+++ b/src/main/java/com/example/trace/point/PointService.java
@@ -1,0 +1,63 @@
+package com.example.trace.point;
+
+import com.example.trace.global.response.CursorResponse;
+import com.example.trace.global.response.CursorResponse.CursorMeta;
+import com.example.trace.user.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    @Transactional(readOnly = true)
+    public CursorResponse<PointResponse> getPage(Integer size, Long id, LocalDateTime dateTime, User user) {
+        List<Point> points;
+
+        if (isFirstPage(id, dateTime)) {
+            points = pointRepository.findFirstPage(
+                    user,
+                    PageRequest.of(0, size, Sort.by("createdAt").descending().and(Sort.by("id").descending()))
+            );
+        } else {
+            points = pointRepository.findNextPage(
+                    user,
+                    dateTime,
+                    id,
+                    PageRequest.of(0, size, Sort.by("createdAt").descending().and(Sort.by("id").descending()))
+            );
+        }
+
+        List<PointResponse> response = points.stream()
+                .map(PointResponse::fromEntity)
+                .toList();
+
+        boolean hasNext = response.size() == size;
+        PointResponse last = response.get(response.size() - 1);
+        CursorMeta nextCursor = getNextCursorFrom(last, hasNext);
+
+        return new CursorResponse<>(response, hasNext, nextCursor);
+    }
+
+    private CursorResponse.CursorMeta getNextCursorFrom(PointResponse last, boolean hasNext) {
+        if (!hasNext) {
+            return null;
+        }
+
+        return CursorMeta.builder()
+                .dateTime(last.getCreatedAt())
+                .id(last.getId())
+                .build();
+    }
+
+    private boolean isFirstPage(Long id, LocalDateTime time) {
+        return id == null || time == null;
+    }
+}

--- a/src/main/java/com/example/trace/point/PointSource.java
+++ b/src/main/java/com/example/trace/point/PointSource.java
@@ -1,0 +1,28 @@
+package com.example.trace.point;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PointSource {
+
+    // 선행 인증 게시글
+    GOOD_DEED_POST_TEXT(50, "선행 인증 (텍스트)"),
+    GOOD_DEED_POST_IMAGE(50, "선행 인증 (이미지)"),
+
+    // 미션 인증 게시글
+    MISSION_POST_TEXT(150, "미션 인증 (텍스트)"),
+    MISSION_POST_IMAGE(150, "미션 인증 (이미지)"),
+
+    // 출석
+    ATTENDANCE(25, "출석 체크"),
+
+    // 보너스
+    // 연속 선행 보너스는 일수에 따라 포인트가 달라지므로, 기본 포인트는 0으로 설정합니다.
+    // 실제 포인트 지급은 서비스 로직에서 계산하여 부여합니다.
+    CONSECUTIVE_DAYS_BONUS(0, "연속 선행 일수 보너스");
+
+    private final int points;
+    private final String description;
+}

--- a/src/main/java/com/example/trace/point/PointSource.java
+++ b/src/main/java/com/example/trace/point/PointSource.java
@@ -1,5 +1,6 @@
 package com.example.trace.point;
 
+import com.example.trace.gpt.dto.VerificationDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,22 +8,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PointSource {
 
-    // 선행 인증 게시글
-    GOOD_DEED_POST_TEXT(50, "선행 인증 (텍스트)"),
-    GOOD_DEED_POST_IMAGE(50, "선행 인증 (이미지)"),
-
-    // 미션 인증 게시글
-    MISSION_POST_TEXT(150, "미션 인증 (텍스트)"),
-    MISSION_POST_IMAGE(150, "미션 인증 (이미지)"),
-
-    // 출석
+    GOOD_DEED_POST(50, "선행 인증"),       // 기본 50점
+    MISSION_POST(150, "미션 인증"),       // 기본 150점
     ATTENDANCE(25, "출석 체크"),
-
-    // 보너스
-    // 연속 선행 보너스는 일수에 따라 포인트가 달라지므로, 기본 포인트는 0으로 설정합니다.
-    // 실제 포인트 지급은 서비스 로직에서 계산하여 부여합니다.
     CONSECUTIVE_DAYS_BONUS(0, "연속 선행 일수 보너스");
 
-    private final int points;
+    private static final int FULL_VERIFICATION_MULTIPLIER = 2;
+    private final int basePoints;
     private final String description;
+
+    public int calculatePointFor(VerificationDto verification) {
+        int finalPoints = getBasePoints();
+
+        if (verification.isTextResult() && verification.isImageResult()) {
+            return finalPoints * FULL_VERIFICATION_MULTIPLIER;
+        }
+        return finalPoints;
+    }
 }

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -69,7 +69,6 @@ public class PostServiceImpl implements PostService {
         if (verificationDto != null) {
             verification = verificationDto.toEntity();
             user.updateVerification(verificationDto, postType);
-            pointService.grantPointForPost(postType, user, verificationDto);
             birdLevel = birdService.checkAndUnlockBirdLevel(user).orElse(null);
             if (birdLevel != null) {
                 isLevelUp = true;
@@ -95,11 +94,12 @@ public class PostServiceImpl implements PostService {
                         postCreateDto.getPostType() == PostType.MISSION ? postCreateDto.getMissionContent() : null)
                 .build();
 
+        Post savedPost = postRepository.save(post);
+
         if (verification != null) {
             verification.connectToPost(post);
+            pointService.grantPointForPost(savedPost, user, verificationDto);
         }
-
-        Post savedPost = postRepository.save(post);
 
         // TODO(seobeeeee1001): 이미지 업로드 로직 분리
         List<MultipartFile> imageFiles = postCreateDto.getImageFiles();

--- a/src/main/java/com/example/trace/util/HttpResponseUtil.java
+++ b/src/main/java/com/example/trace/util/HttpResponseUtil.java
@@ -1,20 +1,20 @@
-package com.example.trace.Util;
+package com.example.trace.util;
 
 
-import org.springframework.http.HttpStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
 
 public class HttpResponseUtil {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     // 성공 응답 설정
-    public static void setSuccessResponse(HttpServletResponse response, HttpStatus status, Object data) throws IOException {
+    public static void setSuccessResponse(HttpServletResponse response, HttpStatus status, Object data)
+            throws IOException {
         response.setStatus(status.value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
@@ -28,7 +28,8 @@ public class HttpResponseUtil {
     }
 
     // 실패 응답 설정
-    public static void setErrorResponse(HttpServletResponse response, HttpStatus status, String error, String message) throws IOException {
+    public static void setErrorResponse(HttpServletResponse response, HttpStatus status, String error, String message)
+            throws IOException {
         response.setStatus(status.value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/example/trace/util/StringUtil.java
+++ b/src/main/java/com/example/trace/util/StringUtil.java
@@ -1,0 +1,23 @@
+package com.example.trace.util;
+
+public class StringUtil {
+    public static final int PREVIEW_CONTENT_LENGTH = 100;
+    public static final int SHORT_PREVIEW_CONTENT_LENGTH = 20;
+
+    public static String truncate(String content, int maxLength) {
+        if (content == null) {
+            return null;
+        }
+        return content.length() <= maxLength
+                ? content
+                : content.substring(0, maxLength) + "...";
+    }
+
+    public static String truncate(String content) {
+        return truncate(content, PREVIEW_CONTENT_LENGTH);
+    }
+
+    public static String truncateLess(String content) {
+        return truncate(content, SHORT_PREVIEW_CONTENT_LENGTH);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: local-mysql
+    active: ${SPRING_PROFILES_ACTIVE}
   jpa:
     properties:
       hibernate:
@@ -61,6 +61,7 @@ springdoc:
     - /reports/**
     - /admin/reports/**
     - /notifications/**
+    - /points/**
 
 # OAuth2 클라이언트 설정 - API 키 관리, 외부에 노출되면 안 됨
 oauth2:
@@ -94,18 +95,18 @@ logging:
 
 firebase:
   config-path: firebase/firebase_service_key.json
----
 
-# 개발 환경 설정
+---
+# 운영 환경 설정
 spring:
   config:
     activate:
-      on-profile: dev
+      on-profile: prod
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://awseb-e-n4aeqm25qy-stack-awsebrdsdatabase-sdzqapxzvgnq.c7oqi6uuacld.ap-northeast-2.rds.amazonaws.com:3306/ebdb?serverTimezone=Asia/Seoul&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&useLegacyDatetimeCode=false
-    username: ${DB_USERNAME}
+    url: jdbc:mysql://${DB_HOST}:3306/ebdb?serverTimezone=Asia/Seoul&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&useLegacyDatetimeCode=false
+    username: ebroot
     password: ${DB_PASSWORD}
     hikari:
       maximum-pool-size: 5
@@ -179,7 +180,70 @@ management:
         enabled: true
 
 ---
+# 개발 환경 설정
+spring:
+  config:
+    activate:
+      on-profile: dev
 
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_HOST}:3306/ebdb?serverTimezone=Asia/Seoul&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&useLegacyDatetimeCode=false
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 5
+      connection-timeout: 30000
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: false
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc:
+          time_zone: Asia/Seoul
+          batch_size: 20
+        timezone:
+          default_storage: NORMALIZE
+        type:
+          preferred_instant_jdbc_type: TIMESTAMP
+        order_inserts: true
+        order_updates: true
+        query:
+          plan_cache_max_size: 64
+
+  # 한국 시간대 설정 추가 (dev 프로파일에서 누락되었던 부분)
+  jackson:
+    time-zone: Asia/Seoul
+    date-format: yyyy-MM-dd HH:mm:ss
+    serialization:
+      write-dates-as-timestamps: false
+
+  sql:
+    init:
+      mode: never
+
+# 서버 설정
+server:
+  port: 5000
+  servlet:
+    context-path: /api/v1
+  error:
+    include-message: always
+    include-binding-errors: always
+    include-stacktrace: never
+    include-exception: false
+  tomcat:
+    basedir: ./temp  # Custom temp directory for Tomcat
+    max-http-form-post-size: 2MB
+    max-swallow-size: 2MB
+
+
+---
 # 로컬 환경 설정
 spring:
   config:
@@ -190,69 +254,10 @@ spring:
     init:
       mode: never
 
-  # H2 데이터베이스 설정
-  datasource:
-    url: jdbc:h2:file:./data/tracedb
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-
-  # H2 콘솔 활성화
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        use_sql_comments: true
-        jdbc:
-          time_zone: Asia/Seoul
-        timezone:
-          default_storage: NORMALIZE
-
-  # 로컬에서도 시간대 설정 일관성 유지
-  jackson:
-    time-zone: Asia/Seoul
-    date-format: yyyy-MM-dd HH:mm:ss
-    serialization:
-      write-dates-as-timestamps: false
-
-  app:
-    base-url: http://localhost:8080/api/v1
-
-# 서버 설정
-server:
-  port: 8080
-  servlet:
-    context-path: /api/v1
-  error:
-    include-message: always
-    include-binding-errors: always
-    include-stacktrace: never
-    include-exception: false
-  tomcat:
-    basedir: ./temp  # Custom temp directory for Tomcat
-
----
-spring:
-  config:
-    activate:
-      on-profile: local-mysql
-
-  sql:
-    init:
-      mode: never
-
   datasource:
     url: jdbc:mysql://localhost:3306/tracedb?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: qwer1234
+    password: ${LOCAL_MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
선행 인증 시 발급되는 포인트를 저장하고 사용자의 적립된 포인트를 확인할 수 있는 기능 추가

## 2. ✨새롭게 변경된 점
`point` 도메인 모듈을 새로 만들었습니다. 사용자에게 저장되는 Long타입의 `verificationScore`와 `Point` 엔티티를 구분하였습니다.

Point는 저장되는 데이터일 뿐이고, 이를 가공해서 사용자의 `verificationScore`를 만드는 것은 아니기 때문입니다. 그리고 포인트의 적립은 다양한 방법으로 이뤄질 수 있어서 일단 구분지었습니다.

하지만 응집성을 위해 Point 도메인에서 사용자의 score를 연산하는 로직은 있어야 할 것 같네요. 추후 수정해보겠습니다.

그리고 `StringUtil`을 만들었습니다. `/posts/feed`나 `/points/list`처럼 게시글의 내용이 보이지만 preview로 제공되는 환경에선 미리 잘라서 저장하거나 값을 제거하여 클라이언트에게 넘기는게 좋다고 판단했기 때문입니다. 용량 문제도 있고 http 응답 패킷의 크기가 커지는 것도 방지할 수 있어 꽤 자주 쓰일 것 같았어요.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
