### PR TITLE
댓글 관련 오류 해결

### DIFF
--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
@@ -163,6 +163,14 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .from(emotion)
                 .where(emotion.post.eq(post));
 
+        Expression<Long> activeCommentCount =
+                JPAExpressions.select(comment.count())
+                        .from(comment)
+                        .where(
+                                comment.post.eq(post),
+                                comment.isDeleted.eq(false)
+                        );
+
 
         return queryFactory
                 .select(Projections.constructor(PostFeedDto.class,
@@ -175,7 +183,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                         post.user.profileImageUrl,
                         imageUrlExpr,
                         post.viewCount,
-                        post.commentList.size().longValue(),
+                        activeCommentCount,
                         post.createdAt,
                         post.updatedAt,
                         isVerifiedExpr,

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
@@ -252,6 +252,14 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     ) {
         QPost post = QPost.post;
         QComment comment = QComment.comment;
+        QComment child = new QComment("child");
+
+        BooleanExpression hasActiveChild =
+                JPAExpressions.selectOne()
+                        .from(child)
+                        .where(child.parent.id.eq(comment.id)
+                                .and(child.isDeleted.eq(false)))
+                        .exists();
 
         List<Long> parentCommentIds = queryFactory
                 .select(comment.id)
@@ -260,7 +268,8 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                         comment.post.id.eq(postId),
                         comment.parent.isNull(), // 부모 댓글만
                         commentCursorCondition(cursorDateTime, cursorId),
-                        commentUserNotBlocked(providerId) // 댓글 작성자가 차단되지 않은 경우
+                        commentUserNotBlocked(providerId), // 댓글 작성자가 차단되지 않은 경우
+                        comment.isDeleted.eq(false).or(hasActiveChild) // 삭제되지 않았거나 삭제되지 않은 자식 댓글이 있는 경우
                 )
                 .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .limit(size)
@@ -298,13 +307,13 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .from(comment)
                 .leftJoin(comment.user)
                 .where(
-                        comment.id.in(parentCommentIds).or(comment.parent.id.in(parentCommentIds)),
+                        comment.id.in(parentCommentIds).
+                                or(comment.parent.id.in(parentCommentIds).and(comment.isDeleted.eq(false))),
                         commentUserNotBlocked(providerId)
                 )
                 .orderBy(comment.parent.id.asc().nullsFirst(),
                         comment.createdAt.asc())
                 .fetch();
-
 
         return allComments;
     }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

댓글 삭제 로직은 현재 소프트 삭제로 수행된다.

댓글을 참조하고 있는 `report` 엔티티가 함께 삭제되면 향후에 신고 관련 내용을 파악하지 못하기 때문에 

일단은 댓글 삭제를 소프트 삭제로 남겨두었다. 

현재 요구되고 있는 사항은

1. 삭제된 댓글 조회 관련

    - 삭제된 대댓글은 불러오지 말기.

    - 삭제된 댓글이지만 삭제되지 않은 대댓글이 있다면 불러오기

2. 삭제된 댓글, 대댓글에 대한 카운트는 세지 말기.


### 댓글 조회 방식

`querydsl`을 통해 조건식을 모듈화하고 쿼리를 동적으로 생성하여 조회한다. 

댓글 조회는 원댓글의 `id`를 리스트로 가져온 뒤, 해당 리스트에 본인의 `id`가 있거나 본인 `parent`의 값이 있다면 

가져오는 방식으로 구현돼있다.

요구 사항을 충족시키기 위해서 다음과 같은 조건식을 추가하였다. 

1. 원댓글의 `id`를 리스트로 가져오는 쿼리에 대댓글 중 삭제되지 않은 것의 존재 여부를 반환하는 서브쿼리를 조건식으로 추가

2. 해당 리스트에 본인 `parent`의 `id` 존재 여부 확인할 때,` isDeleted = false` 를  `AND` 조건으로 추가

3. 게시글 커서 조회 시, 기존 `count` 서브 쿼리에 `isDeleted = false` 추가



 

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들