### PR TITLE
/post/feed 응답 dto에 content가 길면 줄여서 보내도록 변경

### DIFF
--- a/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
@@ -2,19 +2,17 @@ package com.example.trace.post.dto.post;
 
 import com.example.trace.emotion.EmotionType;
 import com.example.trace.post.domain.PostType;
+import com.example.trace.util.StringUtil;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Data
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Schema(description = "게시글 피드 DTO")
 public class PostFeedDto {
     @Schema(description = "게시글 ID", example = "1")
@@ -66,4 +64,27 @@ public class PostFeedDto {
 
     @Schema(description = "내가 한 감정표현 타입", example = "HEARTWARMING", nullable = true)
     private EmotionType myEmotionType;
+
+    public PostFeedDto(Long postId, PostType postType, String title, String content, String providerId, String nickname,
+                       String profileImageUrl, String imageUrl, Long viewCount, Long commentCount,
+                       LocalDateTime createdAt,
+                       LocalDateTime updatedAt, boolean isVerified, boolean isOwner, Long emotionCountSum,
+                       EmotionType myEmotionType) {
+        this.postId = postId;
+        this.postType = postType;
+        this.title = title;
+        this.content = StringUtil.truncate(content);
+        this.providerId = providerId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.imageUrl = imageUrl;
+        this.viewCount = viewCount;
+        this.commentCount = commentCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.isVerified = isVerified;
+        this.isOwner = isOwner;
+        this.emotionCountSum = emotionCountSum;
+        this.myEmotionType = myEmotionType;
+    }
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
필요 이상으로 긴 게시글 내용을 줄여서 보여주도록 변경하였습니다.

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
